### PR TITLE
fix: fix/slim up Strapi Dockerfile

### DIFF
--- a/strapi/.dockerignore
+++ b/strapi/.dockerignore
@@ -1,8 +1,11 @@
 .gitignore
+.git/
 .dockerignore
-Dockerfile
+*Dockerfile*
+*docker-compose*
 dist
 node_modules
+npm-debug.log
 .env
 .env.example
 .env.test
@@ -20,6 +23,11 @@ misc
 .nvmrc
 .tmp/
 .cache/
-.git/
 build/
 data/
+# kustomize files
+kubernetes/
+# bratiska-cli manifest files
+manifest-*.y?ml
+# markdown files
+**/*.md

--- a/strapi/Dockerfile
+++ b/strapi/Dockerfile
@@ -1,57 +1,66 @@
-# development
-FROM node:16 AS dev
-
-RUN apt-get update && apt-get install -y git \
-    vim \
-    libvips-dev
-
-ARG NODE_ENV=development
-ENV NODE_ENV=${NODE_ENV}
-
-WORKDIR /home/node/app
-COPY package*.json ./
-COPY yarn.lock ./
+FROM node:16-alpine AS build-base
+RUN apk update \
+ && apk add --no-cache build-base \
+                       gcc \
+                       autoconf \
+                       automake \
+                       zlib-dev \
+                       libpng-dev \
+                       vips-dev > /dev/null 2>&1
+WORKDIR /build
+COPY ./package.json ./yarn.lock ./
+# Uncomment if you need any to apply any patches
 COPY patches ./patches
+# copy any installation files for Strapi plugins you want to build. For example:
+# COPY src/plugins/<package-name>/package.json src/plugins/<package-name>/yarn.lock ./src/plugins/<package-name>
+# Or leave empty (do not add anyting) if you don't have any custom plugins (most likely ./plugins directory)
 COPY src/plugins/ceremonies-debtor-list/package.json ./src/plugins/ceremonies-debtor-list/package.json
 COPY src/plugins/ceremonies-debtor-list/yarn.lock ./src/plugins/ceremonies-debtor-list/yarn.lock
 
-RUN yarn install
-COPY . ./
+FROM build-base AS install-prod
+RUN yarn config set network-timeout 600000 -g \
+ && yarn install --production
 
-RUN yarn build
+FROM install-prod as build
+WORKDIR /build/app
+COPY ./ .
+RUN yarn install --development && yarn build
 
-EXPOSE 1337
-CMD ["yarn", "develop"]
-
-# production
-FROM node:16 AS prod
-
-RUN apt-get update && apt-get install -y git \
-    libvips-dev
-
+FROM node:16-alpine AS app-base
+RUN apk add --no-cache vips-dev \
+                       tini \
+ && mkdir -p /home/node/app \
+ && chown node:node /home/node/app
 USER node
-
-RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
 WORKDIR /home/node/app
-
-ARG NODE_ENV=production
-ENV NODE_ENV=${NODE_ENV}
-# ENV PATH /home/node/node_modules/.bin:$PATH
-
-COPY --chown=node:node package*.json ./
-COPY --chown=node:node yarn.lock ./
-COPY --chown=node:node patches ./patches
-COPY --chown=node:node src/plugins/ceremonies-debtor-list/package.json ./src/plugins/ceremonies-debtor-list/package.json
-COPY --chown=node:node src/plugins/ceremonies-debtor-list/yarn.lock ./src/plugins/ceremonies-debtor-list/yarn.lock
-
-RUN yarn config set network-timeout 600000 -g
-RUN yarn install --production
-
-COPY . ./
-
-USER root
-RUN yarn build && chown -R node:node /home/node/app
-USER node
-
+# Adds strapi cli to the PATH
+ENV PATH=/home/node/app/node_modules/.bin:$PATH
+ENV NODE_ENV=production
 EXPOSE 1337
-CMD ["yarn", "start"]
+ARG GIT_COMMIT="undefined"
+ENV GIT_COMMIT=$GIT_COMMIT
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.source="https://github.com/bratislava/nest-magproxy" \
+      org.opencontainers.image.licenses="EUPL-1.2"
+ENTRYPOINT [ "/sbin/tini", "--" ]
+
+FROM app-base AS dev
+ENV NODE_ENV=development
+COPY --chown=node:node --from=build /build/node_modules ./node_modules
+CMD [ "yarn", "develop" ]
+
+FROM app-base AS prod
+COPY --chown=node:node --from=build /build/app/favicon.ico /build/package.json /build/yarn.lock /build/app/tsconfig.json ./
+COPY --chown=node:node --from=install-prod /build/node_modules ./node_modules
+COPY --chown=node:node --from=build /build/app/config ./config
+COPY --chown=node:node --from=build /build/app/public ./public
+COPY --chown=node:node --from=build /build/app/dist ./dist
+# COPY to final image any built Strapi plugins. In this stage you will *ONLY* need
+# - plugins/<name>/yarn.lock
+# - plugins/<name>/package.json
+# - plugins/<name>/dist/
+# Or leave empty (do not add anyting) if you don't have any custom plugins (most likely ./plugins directory)
+COPY --chown=node:node --from=install-prod /build/src/plugins/ceremonies-debtor-list/yarn.lock ./src/plugins/ceremonies-debtor-list/yarn.lock
+COPY --chown=node:node --from=install-prod /build/src/plugins/ceremonies-debtor-list/package.json ./src/plugins/ceremonies-debtor-list/package.json
+COPY --chown=node:node --from=build /build/app/src/plugins/ceremonies-debtor-list/dist ./src/plugins/ceremonies-debtor-list/dist
+CMD [ "strapi", "start" ]

--- a/strapi/Dockerfile
+++ b/strapi/Dockerfile
@@ -40,7 +40,7 @@ EXPOSE 1337
 ARG GIT_COMMIT="undefined"
 ENV GIT_COMMIT=$GIT_COMMIT
 LABEL org.opencontainers.image.revision="${GIT_COMMIT}" \
-      org.opencontainers.image.source="https://github.com/bratislava/nest-magproxy" \
+      org.opencontainers.image.source="https://github.com/bratislava/marianum.sk" \
       org.opencontainers.image.licenses="EUPL-1.2"
 ENTRYPOINT [ "/sbin/tini", "--" ]
 

--- a/strapi/Dockerfile
+++ b/strapi/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update \
                        automake \
                        zlib-dev \
                        libpng-dev \
-                       vips-dev > /dev/null 2>&1
+                       vips-dev
 WORKDIR /build
 COPY ./package.json ./yarn.lock ./
 # Uncomment if you need any to apply any patches
@@ -28,8 +28,8 @@ RUN yarn install --development && yarn build
 
 FROM node:16-alpine AS app-base
 RUN apk add --no-cache vips-dev \
-                       tini \
- && mkdir -p /home/node/app \
+                       tini
+RUN mkdir -p /home/node/app \
  && chown node:node /home/node/app
 USER node
 WORKDIR /home/node/app

--- a/strapi/package.json
+++ b/strapi/package.json
@@ -27,7 +27,8 @@
     "strapi-plugin-meilisearch": "^0.9.1",
     "strapi-plugin-navigation": "^2.2.1",
     "strapi-plugin-placeholder": "^4.3.6",
-    "strapi-provider-upload-ts-minio": "^3.1.0"
+    "strapi-provider-upload-ts-minio": "^3.1.0",
+    "xlsx": "^0.18.5"
   },
   "author": {
     "name": "The City of Bratislava"


### PR DESCRIPTION
* Almost entirely change Dockerfile 
  - Switch to alpine distribution based on (un)official docker recommendations https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/installation/docker.html#production-environments
  - Separate Dockerfile into multiple stages to keep DRY as possible, to always make change only in one place
  - Added tini as entrypoint to the image
  - Added opencontainers labels for the image and ENV variable which should hold current commit hash (if build with --build-args)
  - Limit the number of files that are copied to the final image. Kept only the necessary files to start up strapi (this might need some changes in the future)
  - Added comments for future use/copy to other projects about plugins and patches
  - Keep development stage without build as you probably want to mount your own file
* Move one package from plugin to main package.json, which helped us to limit the size of image by 400MB
* Added more stuff into .dockerignore as in the current form it copied a lot of unnecessary files, which slowed down the build time