### PR TITLE
fix: fix missing *.js from plugins directory

### DIFF
--- a/strapi/Dockerfile
+++ b/strapi/Dockerfile
@@ -59,8 +59,10 @@ COPY --chown=node:node --from=build /build/app/dist ./dist
 # - plugins/<name>/yarn.lock
 # - plugins/<name>/package.json
 # - plugins/<name>/dist/
+# - plugins/<name>/*.js
 # Or leave empty (do not add anyting) if you don't have any custom plugins (most likely ./plugins directory)
 COPY --chown=node:node --from=install-prod /build/src/plugins/ceremonies-debtor-list/yarn.lock ./src/plugins/ceremonies-debtor-list/yarn.lock
 COPY --chown=node:node --from=install-prod /build/src/plugins/ceremonies-debtor-list/package.json ./src/plugins/ceremonies-debtor-list/package.json
 COPY --chown=node:node --from=build /build/app/src/plugins/ceremonies-debtor-list/dist ./src/plugins/ceremonies-debtor-list/dist
+COPY --chown=node:node --from=build /build/app/src/plugins/ceremonies-debtor-list/*.js ./src/plugins/ceremonies-debtor-list/
 CMD [ "strapi", "start" ]


### PR DESCRIPTION
* We didn't copy `*.js` files from plugin directory, which as it turns out are needed for running the plugin. Added a wildcard docker COPY from build stage to copy over all `*.js` files