### PR TITLE
Fix of dual arrow in external links

### DIFF
--- a/next/components/atoms/RichText.tsx
+++ b/next/components/atoms/RichText.tsx
@@ -87,7 +87,7 @@ const RichText = ({ className, content, coloredTable = true }: RichTextProps) =>
               href={href ?? '#'}
               target={isExternal ? '_blank' : '_self'}
               variant="regular"
-              noArrow={isExternal}
+              noArrow
             >
               {children[0]}
               {isExternal && ' ↗\u{0000FE0E}'}

--- a/next/components/atoms/RichText.tsx
+++ b/next/components/atoms/RichText.tsx
@@ -83,9 +83,14 @@ const RichText = ({ className, content, coloredTable = true }: RichTextProps) =>
         a: ({ href, children }) => {
           const isExternal = href?.startsWith('http')
           return (
-            <MLink href={href ?? '#'} target={isExternal ? '_blank' : '_self'} variant="regular">
+            <MLink
+              href={href ?? '#'}
+              target={isExternal ? '_blank' : '_self'}
+              variant="regular"
+              noArrow={isExternal}
+            >
               {children[0]}
-              {isExternal && ' ↗'}
+              {isExternal && ' ↗\u{0000FE0E}'}
             </MLink>
           )
         },


### PR DESCRIPTION
- Added noArrow prop handling when internal link arrow shows in RichText component when href "isExternal"
- Used Unicode selector after arrow icon according to Markdown component from bratislava.sk
- Tested on few pages where I found external links. Seems to be working fine