### PR TITLE
Fix: Remove `placeholder` and `blurDataURL` props from MImage

### DIFF
--- a/next/components/atoms/MImage.tsx
+++ b/next/components/atoms/MImage.tsx
@@ -5,6 +5,7 @@ import { ComponentProps } from 'react'
 // After update to Next.js, loading images is broken (returns 503 and makes the server crash for a moment), this is a
 // temporary fix.
 export const customImageLoader: ImageLoader = ({ src, width, quality }) => {
+  // eslint-disable-next-line no-secrets/no-secrets
   // https://sourcegraph.com/github.com/vercel/next.js@33d4694ba7a3847464b32d33229fd88cadadd64c/-/blob/packages/next/client/legacy/image.tsx?L168
   if (src.endsWith('.svg')) {
     return src
@@ -15,26 +16,17 @@ export const customImageLoader: ImageLoader = ({ src, width, quality }) => {
   }`
 }
 
-export type MImageImage = Pick<
-  UploadFile,
-  'url' | 'alternativeText' | 'placeholder' | 'width' | 'height'
->
+export type MImageImage = Pick<UploadFile, 'url' | 'alternativeText' | 'width' | 'height'>
 
-type MImageProps = Omit<
-  ComponentProps<typeof Image>,
-  'src' | 'alt' | 'placeholder' | 'blurDataURL' | 'width' | 'height'
-> & {
+type MImageProps = Omit<ComponentProps<typeof Image>, 'src' | 'alt' | 'width' | 'height'> & {
   image: MImageImage
-  disableBlurPlaceholder?: boolean
 }
 
-// TODO: Placeholder doesn't respect objectFit when used with layout="fill".
-const MImage = ({ image, disableBlurPlaceholder = false, ...rest }: MImageProps) => (
+const MImage = ({ image, ...rest }: MImageProps) => (
   <Image
     src={image.url}
     alt={image.alternativeText ?? ''}
-    placeholder={disableBlurPlaceholder || !image.placeholder ? undefined : 'blur'}
-    blurDataURL={disableBlurPlaceholder || !image.placeholder ? undefined : image.placeholder}
+    // TODO: Placeholder doesn't respect objectFit when used with layout="fill".
     // Next shows Image with src "..." and "layout='fill'" has unused properties assigned. Please remove "width" and "height".
     width={rest.fill ? undefined : (image.width ?? undefined)}
     height={rest.fill ? undefined : (image.height ?? undefined)}

--- a/next/graphql/index.ts
+++ b/next/graphql/index.ts
@@ -3735,7 +3735,6 @@ export type UploadFile = {
   height?: Maybe<Scalars['Int']>;
   mime: Scalars['String'];
   name: Scalars['String'];
-  placeholder?: Maybe<Scalars['String']>;
   previewUrl?: Maybe<Scalars['String']>;
   provider: Scalars['String'];
   provider_metadata?: Maybe<Scalars['JSON']>;
@@ -3779,7 +3778,6 @@ export type UploadFileFiltersInput = {
   name?: InputMaybe<StringFilterInput>;
   not?: InputMaybe<UploadFileFiltersInput>;
   or?: InputMaybe<Array<InputMaybe<UploadFileFiltersInput>>>;
-  placeholder?: InputMaybe<StringFilterInput>;
   previewUrl?: InputMaybe<StringFilterInput>;
   provider?: InputMaybe<StringFilterInput>;
   provider_metadata?: InputMaybe<JsonFilterInput>;
@@ -3800,7 +3798,6 @@ export type UploadFileInput = {
   height?: InputMaybe<Scalars['Int']>;
   mime?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
-  placeholder?: InputMaybe<Scalars['String']>;
   previewUrl?: InputMaybe<Scalars['String']>;
   provider?: InputMaybe<Scalars['String']>;
   provider_metadata?: InputMaybe<Scalars['JSON']>;

--- a/next/pages/styleguide/index.tsx
+++ b/next/pages/styleguide/index.tsx
@@ -83,10 +83,9 @@ const image: UploadFile = {
   provider: 'local',
   provider_metadata: null,
   createdAt: '2022-08-24T20:30:23.750Z',
-  placeholder:
-    'data:image/jpeg;base64,/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAAGAAoDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAUG/8QAIRAAAQQABwEBAAAAAAAAAAAAAQIDBAUABxESEyExBqH/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AkZQSpl3UW1bDkphOQqlyZvSyklL7ShwuIV6DtJB1B8696yDWYP08NpEWPYOcLKQ2jV1QO1PQ/BhhgP/Z',
 }
 
+// eslint-disable-next-line const-case/uppercase
 const richText = '# Heading 1'
 
 type WrapperProps = {


### PR DESCRIPTION
### Description

- After running `yarn gen`, the `placeholder` prop was missing from `UploadFile` fragment, and caused an error
- `blurDataURL` was removed as it wasn't needed after removing `strapi-plugin-placeholder`