### PR TITLE
Add scrollbar-hide to appropriate homepage components

### DIFF
--- a/next/components/molecules/Section.tsx
+++ b/next/components/molecules/Section.tsx
@@ -118,7 +118,7 @@ const Section = ({
             {
               '-mb-6 grid gap-6 pb-6 md:grid-cols-2 lg:grid-cols-4': cardGrid === 'cards',
               '-mb-6 grid gap-6 pb-6 md:grid-cols-2 lg:grid-cols-3': cardGrid === 'bundles',
-              '-mb-6 flex gap-6 overflow-x-auto pb-6 md:grid md:grid-cols-2 lg:grid-cols-4':
+              '-mb-6 flex gap-6 overflow-x-auto pb-6 scrollbar-hide md:grid md:grid-cols-2 lg:grid-cols-4':
                 cardGrid === 'serviceCards',
             },
             childrenWrapperClassName,

--- a/next/components/sections/ArticleGroup.tsx
+++ b/next/components/sections/ArticleGroup.tsx
@@ -10,7 +10,7 @@ const ArticleGroup = ({ articles }: ArticleGroupProps) => {
   const { getFullPath } = useGetFullPath()
 
   return (
-    <div className="-mb-6 flex grid-cols-2 gap-4 overflow-x-auto pb-6 md:grid md:gap-6 lg:grid-cols-4">
+    <div className="-mb-6 flex grid-cols-2 gap-4 overflow-x-auto pb-6 scrollbar-hide md:grid md:gap-6 lg:grid-cols-4">
       {articles?.map((article) => {
         const { title, publishedAt, coverMedia, newsCategory } = article.attributes ?? {}
 

--- a/next/components/sections/HomepageProceduresSection.tsx
+++ b/next/components/sections/HomepageProceduresSection.tsx
@@ -55,7 +55,7 @@ const HomepageProceduresSection = ({
             <TabItem key={procedure.key} title={procedure.title}>
               <ol
                 className={cx('flex', {
-                  'w-full gap-4 overflow-x-auto': isMobile,
+                  'w-full gap-4 overflow-x-auto scrollbar-hide': isMobile,
                   'flex-col gap-4': !isMobile,
                 })}
               >


### PR DESCRIPTION
### Description

Tiny CSS changes.

### Testing

On Marianum homepage, on small screens, when there is a section that overflows to the right and can be scrollew to reveal more cards, no scrollbar should be visible.