### PR TITLE
#331 Implement NOT_FOUND with revalidate property

### DIFF
--- a/next/components/molecules/Navigation/NavigationProvider/generateStaticPathsAndProps.ts
+++ b/next/components/molecules/Navigation/NavigationProvider/generateStaticPathsAndProps.ts
@@ -10,6 +10,7 @@ import {
 } from '@/components/molecules/Navigation/NavigationProvider/useGetFullPath'
 import { GeneralEntityFragment, NavigationItemFragment } from '@/graphql'
 import { client } from '@/services/graphql/gqlClient'
+import { NOT_FOUND } from '@/utils/consts'
 import { isDefined } from '@/utils/isDefined'
 import { parseNavigation } from '@/utils/parseNavigation'
 
@@ -49,10 +50,6 @@ export const generateStaticPaths = async (
   ) as GetStaticPathsResult<{ fullPath: string[] }>['paths']
 }
 
-const notFound = {
-  notFound: true,
-} as const
-
 /**
  * Shared function to generate static path for a specific route.
  *
@@ -82,7 +79,7 @@ export const generateStaticProps = async <T extends UnionSlugEntityType, Additio
   getAdditionalProps?: (entity: T) => Promise<AdditionalProps>
 }) => {
   if (!params?.fullPath) {
-    return notFound
+    return NOT_FOUND
   }
 
   const { fullPath } = params
@@ -90,7 +87,7 @@ export const generateStaticProps = async <T extends UnionSlugEntityType, Additio
   const slug = last(fullPath)
 
   if (!slug) {
-    return notFound
+    return NOT_FOUND
   }
 
   const [{ navigation, general }, entity, translations] = await Promise.all([
@@ -102,7 +99,7 @@ export const generateStaticProps = async <T extends UnionSlugEntityType, Additio
   const filteredNavigation = navigation.filter(isDefined)
 
   if (!entity || !isCurrentPathValid(fullPathString, entity, filteredNavigation)) {
-    return notFound
+    return NOT_FOUND
   }
 
   const additionalProps = getAdditionalProps

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -26,6 +26,7 @@ import {
 import { getNewsListingPrefetch } from '@/services/fetchers/newsListingFetcher'
 import { upcomingCeremoniesPrefetch } from '@/services/fetchers/upcomingCeremoniesFetcher'
 import { client } from '@/services/graphql/gqlClient'
+import { NOT_FOUND } from '@/utils/consts'
 import { isDefined } from '@/utils/isDefined'
 import { prefetchSections } from '@/utils/prefetchSections'
 
@@ -132,9 +133,7 @@ export const getStaticProps: GetStaticProps = async ({
   const filteredNavigation = navigation.filter(isDefined)
 
   if (!homePage?.data) {
-    return {
-      notFound: true,
-    }
+    return NOT_FOUND
   }
 
   return {

--- a/next/utils/consts.ts
+++ b/next/utils/consts.ts
@@ -1,1 +1,6 @@
 export const bratislavaTimezone = 'Europe/Bratislava'
+
+export const NOT_FOUND = {
+  notFound: true,
+  revalidate: 10,
+} as const


### PR DESCRIPTION
### Description

See issue for issue description.
The missing element was just to add the revalidate property to any notFound that was returned in getStaticProps.

### Testing

Do these steps:
- Visit some page that doesn't exist yet - for example /404test
- You should end up at the 404 page - this is expected
- Now, create a page in strapi with that slug (404test in this example)
- Wait cca 10 seconds and then refresh the page on frontent (the page which previously led to 404)
- Now the newly created page should be visible. If after even more refreshes, you are stuck with the 404 page, then this PR didn't solve this issue.

