### PR TITLE
#372 Techdebt: Remove `headlessui` library

### DIFF
--- a/next/components/atoms/Select.tsx
+++ b/next/components/atoms/Select.tsx
@@ -74,8 +74,6 @@ const SelectField = <Option extends SelectOption<Sort | string>, IsMulti extends
   defaultValue,
   isDisabled = false,
   isSearchable = false,
-  // Incorrect inference of `isMulti` type caused type mismatch errors. An assertion was added to fix this
-  isMulti = false as IsMulti,
   onChange = () => null,
   className,
   ...rest
@@ -90,7 +88,6 @@ const SelectField = <Option extends SelectOption<Sort | string>, IsMulti extends
         placeholder={placeholder}
         options={options}
         isDisabled={isDisabled}
-        isMulti={isMulti}
         isSearchable={isSearchable}
         defaultValue={defaultValue}
         onChange={onChange}
@@ -98,7 +95,7 @@ const SelectField = <Option extends SelectOption<Sort | string>, IsMulti extends
         className={twMerge(cx('w-full', className))}
         {...rest}
         classNames={{
-          container: () => 'md:z-10',
+          container: (state) => cx({ 'md:z-10': state.selectProps.menuIsOpen }),
           // If a card with a link appears on large and medium screens, the link covers the select dropdown. The `md:z-10` ensures the select always precedes the link
           control: () =>
             'relative flex h-[42px] w-full min-w-0 border border-border bg-white pl-4 pr-1 hover:cursor-pointer outline-none hover:border-border-dark',

--- a/next/components/atoms/Select.tsx
+++ b/next/components/atoms/Select.tsx
@@ -1,161 +1,120 @@
-import { Listbox } from '@headlessui/react'
 import cx from 'classnames'
-import { ReactNode, useCallback, useId, useMemo, useState } from 'react'
-import { usePopper } from 'react-popper'
+import React, { useId } from 'react'
+import Select, {
+  components,
+  DropdownIndicatorProps,
+  OptionProps,
+  Props as ReactSelectProps,
+} from 'react-select'
+import { twMerge } from 'tailwind-merge'
 
 import { ChevronDownIcon } from '@/assets/icons'
-import FieldWrapper from '@/components/atoms/FieldWrapper'
-import { isDefined } from '@/utils/isDefined'
+import { Sort } from '@/components/molecules/SortSelect'
 
-export interface Option {
-  key: string
-  label: ReactNode | string
-  [key: string]: unknown
-}
+export type SelectOption<T extends Sort | string = string> = { value: T; label: string }
 
-type SelectBase = {
-  id?: string
-  placeholder?: string
-  options?: Option[]
-  disabled?: boolean
-  error?: boolean
-  label?: string
-  required?: boolean
-}
+export type SelectProps<
+  Option extends SelectOption<Sort | string> = SelectOption<Sort | string>,
+  IsMulti extends boolean = false,
+> = ReactSelectProps<Option, IsMulti>
 
-export type SingleSelect = {
-  multiple?: false | undefined
-  defaultSelected?: string
-  onSelectionChange?: (selection: string) => void
-} & SelectBase
-
-type MultipleSelect = {
-  multiple: true
-  defaultSelected?: string[]
-  onSelectionChange?: (selection: string[]) => void
-} & SelectBase
-
-export type SelectProps = SingleSelect | MultipleSelect
-
-const Select = ({
-  id,
-  placeholder,
-  options = [],
-  disabled = false,
-  error = false,
-  label,
-  required,
-  multiple,
-  defaultSelected,
-  onSelectionChange = () => {},
-}: SelectProps) => {
-  const generatedId = useId()
-  const generatedOrProvidedId = id ?? generatedId
-
-  const defaultSelectedOptions = isDefined(defaultSelected)
-    ? multiple
-      ? (defaultSelected.map((selected) =>
-          options.find((option) => option.key === selected),
-        ) as Option[])
-      : [options.find((option) => option.key === defaultSelected) as Option]
-    : []
-  const [selectedOptions, setSelectedOptions] = useState<Option[]>(defaultSelectedOptions)
-
-  const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null)
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null)
-  const { styles, attributes } = usePopper(referenceElement, popperElement, {
-    placement: 'bottom',
-    modifiers: [
-      {
-        name: 'offset',
-        options: { offset: [0, 8] },
-      },
-    ],
-  })
-
-  const changeHandler = useCallback(
-    (optionOrOptions: Option | Option[]) => {
-      if (Array.isArray(optionOrOptions)) {
-        setSelectedOptions(optionOrOptions)
-        ;(onSelectionChange as (selection: string[]) => void)(optionOrOptions.map((o) => o.key))
-      } else {
-        setSelectedOptions([optionOrOptions])
-        ;(onSelectionChange as (selection: string) => void)(optionOrOptions.key)
-      }
-    },
-    [onSelectionChange],
-  )
-
-  const selectedOption = useMemo(() => {
-    return selectedOptions[0]
-  }, [selectedOptions])
+const DropdownIndicator = <
+  Option extends SelectOption<Sort | string>,
+  IsMulti extends boolean = false,
+>({
+  ...props
+}: DropdownIndicatorProps<Option, IsMulti>) => {
+  const { menuIsOpen, isDisabled } = props.selectProps
 
   return (
-    <Listbox
-      as="div"
-      className="relative flex w-full"
-      value={multiple ? selectedOptions : selectedOption}
-      onChange={changeHandler}
-      multiple={multiple}
-      disabled={disabled}
-    >
-      <Listbox.Button
-        ref={setReferenceElement}
-        as="button"
-        className="group flex w-full outline-none"
+    <components.DropdownIndicator {...props}>
+      <div
+        className={cx('transform p-2 transition-transform', {
+          'rotate-180': menuIsOpen,
+          'text-content-disabled': isDisabled,
+        })}
       >
-        {({ open }) => (
-          <FieldWrapper
-            error={error}
-            disabled={disabled}
-            label={label}
-            required={required}
-            id={generatedOrProvidedId}
-            hasRightSlot
-          >
-            <div className="flex h-10 w-full min-w-0 cursor-pointer select-none items-center overflow-hidden pl-4">
-              {selectedOptions.length > 0 ? (
-                selectedOptions.map((option, index) => (
-                  <div key={option.key} className="flex whitespace-nowrap">
-                    {index !== 0 && <div className="whitespace-pre-wrap">, </div>}
-                    <div>{option.label}</div>
-                  </div>
-                ))
-              ) : (
-                <div className="truncate text-foreground-placeholder">{placeholder}</div>
-              )}
-            </div>
-            <div className={cx('transform p-2 transition-transform', { 'rotate-180': open })}>
-              <ChevronDownIcon />
-            </div>
-          </FieldWrapper>
-        )}
-      </Listbox.Button>
-
-      <Listbox.Options
-        as="div"
-        ref={setPopperElement as React.Ref<HTMLDivElement>}
-        className="z-20 max-h-[240px] w-full flex-col overflow-y-auto border border-border bg-white outline-none"
-        style={styles.popper}
-        {...attributes.popper}
-      >
-        {options.map((option) => (
-          <Listbox.Option as="div" key={option.key} value={option}>
-            {({ selected, active }) => (
-              <div
-                className={cx('flex h-10 cursor-pointer select-none items-center px-4', {
-                  'bg-primary text-white': selected,
-                  'bg-background-beige': active && !selected,
-                })}
-              >
-                {option.label}
-              </div>
-            )}
-          </Listbox.Option>
-        ))}
-      </Listbox.Options>
-    </Listbox>
+        <ChevronDownIcon />
+      </div>
+    </components.DropdownIndicator>
   )
 }
 
-export default Select
+const CustomOption = <Option extends SelectOption<Sort | string>, IsMulti extends boolean = false>({
+  children,
+  ...props
+}: OptionProps<Option, IsMulti>) => {
+  const { isSelected, isFocused } = props
+
+  return (
+    <components.Option {...props}>
+      <div
+        className={cx(
+          'flex h-10 select-none items-center overflow-hidden text-ellipsis whitespace-nowrap px-4 hover:cursor-pointer',
+          {
+            'bg-primary text-white': isSelected,
+            'bg-background-beige': isFocused && !isSelected,
+          },
+        )}
+      >
+        <div className="truncate">{children}</div>
+      </div>
+    </components.Option>
+  )
+}
+
+/**
+ * Based on OLO: https://github.com/bratislava/olo.sk/blob/master/next/src/components/lib/Select/Select.tsx
+ */
+
+const SelectField = <Option extends SelectOption<Sort | string>, IsMulti extends boolean = false>({
+  value,
+  placeholder,
+  options,
+  defaultValue,
+  isDisabled = false,
+  isSearchable = false,
+  // Incorrect inference of `isMulti` type caused type mismatch errors. An assertion was added to fix this
+  isMulti = false as IsMulti,
+  onChange = () => null,
+  className,
+  ...rest
+}: ReactSelectProps<Option, IsMulti>) => {
+  const id = useId()
+
+  return (
+    <div>
+      <Select
+        id={id}
+        value={value}
+        placeholder={placeholder}
+        options={options}
+        isDisabled={isDisabled}
+        isMulti={isMulti}
+        isSearchable={isSearchable}
+        defaultValue={defaultValue}
+        onChange={onChange}
+        unstyled
+        className={twMerge(cx('w-full', className))}
+        {...rest}
+        classNames={{
+          container: () => 'md:z-10',
+          // If a card with a link appears on large and medium screens, the link covers the select dropdown. The `md:z-10` ensures the select always precedes the link
+          control: () =>
+            'relative flex h-[42px] w-full min-w-0 border border-border bg-white pl-4 pr-1 hover:cursor-pointer outline-none hover:border-border-dark',
+          menu: () => 'z-20 border border-border bg-white mt-2 outline-none',
+          placeholder: () =>
+            cx('truncate text-foreground-placeholder', {
+              'text-content-disabled': isDisabled,
+            }),
+        }}
+        components={{
+          Option: (props) => <CustomOption {...props} />,
+          DropdownIndicator,
+        }}
+      />
+    </div>
+  )
+}
+
+export default SelectField

--- a/next/components/molecules/Accordion/AccordionGroup.tsx
+++ b/next/components/molecules/Accordion/AccordionGroup.tsx
@@ -5,7 +5,11 @@ export type AccordionProps = {
 }
 
 const AccordionGroup = ({ children }: AccordionProps) => {
-  return <div className="flex w-full flex-col gap-5">{children}</div>
+  return (
+    <div role="group" className="flex w-full flex-col gap-5">
+      {children}
+    </div>
+  )
 }
 
 export default AccordionGroup

--- a/next/components/molecules/Accordion/AccordionItem.tsx
+++ b/next/components/molecules/Accordion/AccordionItem.tsx
@@ -1,4 +1,3 @@
-import { Disclosure } from '@headlessui/react'
 import cx from 'classnames'
 import { ReactNode, useContext } from 'react'
 
@@ -14,6 +13,10 @@ export type AccordionItemProps = {
   noBoxStyles?: boolean
 }
 
+/**
+ * Based on OLO: https://github.com/bratislava/olo.sk/blob/master/next/src/components/lib/Accordion/Accordion.tsx
+ */
+
 const AccordionItem = ({
   title,
   additionalInfo,
@@ -24,49 +27,48 @@ const AccordionItem = ({
   const { border: contextBorder } = useContext(sectionContext)
 
   return (
-    <Disclosure>
-      {({ open }) => {
-        return (
+    <AnimateHeight
+      isVisible
+      className="focus-within:[z-1] relative ring-offset-2 transition focus-within:[&:has(:focus-visible)]:ring"
+    >
+      <div>
+        <details
+          className={cx('group flex w-full flex-col bg-white', {
+            'border border-border': (border ?? contextBorder) && !noBoxStyles,
+          })}
+        >
+          <summary
+            className={cx(
+              'flex cursor-pointer justify-between gap-4 text-left text-h5 focus:outline-none',
+              { 'p-4 sm:p-5 md:p-6': !noBoxStyles },
+            )}
+          >
+            <h3 className="py-[3px] text-h5">{title}</h3>
+            {additionalInfo && <div className="pr-6">{additionalInfo}</div>}
+            <div
+              className={cx(
+                'flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white',
+                { 'border border-border': !noBoxStyles },
+              )}
+            >
+              <ChevronDownIcon
+                aria-hidden
+                className="text-primary transition-transform group-open:rotate-180"
+              />
+            </div>
+          </summary>
+
           <div
-            className={cx('flex w-full flex-col bg-white', {
-              'border border-border': (border ?? contextBorder) && !noBoxStyles,
+            className={cx('w-full', {
+              'px-4 pb-4 sm:px-5 sm:pb-5 md:px-6 md:pb-6': !noBoxStyles,
+              'pt-4 sm:pt-5 md:pt-6': noBoxStyles,
             })}
           >
-            <Disclosure.Button
-              className={cx('flex justify-between gap-4 text-left text-h5', {
-                'p-4 sm:p-5 md:p-6': !noBoxStyles,
-              })}
-            >
-              <h3 className="py-[3px] text-h5">{title}</h3>
-              {additionalInfo && <div className="pr-6">{additionalInfo}</div>}
-              <div
-                className={cx(
-                  'flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white',
-                  { 'border border-border': !noBoxStyles },
-                )}
-              >
-                <ChevronDownIcon
-                  className={cx('transform text-primary transition-transform', {
-                    'rotate-180': open,
-                  })}
-                />
-              </div>
-            </Disclosure.Button>
-            <AnimateHeight isVisible={open}>
-              <Disclosure.Panel
-                static
-                className={cx('w-full', {
-                  'px-4 pb-4 sm:px-5 sm:pb-5 md:px-6 md:pb-6': !noBoxStyles,
-                  'pt-4 sm:pt-5 md:pt-6': noBoxStyles,
-                })}
-              >
-                {children}
-              </Disclosure.Panel>
-            </AnimateHeight>
+            {children}
           </div>
-        )
-      }}
-    </Disclosure>
+        </details>
+      </div>
+    </AnimateHeight>
   )
 }
 

--- a/next/components/molecules/CeremoniesDebtors/CemeterySelect.tsx
+++ b/next/components/molecules/CeremoniesDebtors/CemeterySelect.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'next-i18next'
 import { useMemo } from 'react'
 
+import { SelectOption } from '@/components/atoms/Select'
 import SelectWithFetcher from '@/components/molecules/SelectWithFetcher'
 import {
   cemeteriesInCeremoniesFetcher,
@@ -12,17 +13,17 @@ import {
 } from '@/services/fetchers/debtorsSectionFetcher'
 
 type CeremoniesDebtorsCemeterySelectProps = {
-  label?: string
   type: 'ceremonies' | 'debtors'
-  onCemeteryChange: (id: string) => void
+  defaultOption: SelectOption
+  onCemeteryChange: (option: SelectOption | null) => void
 }
 
 const CeremoniesDebtorsCemeterySelect = ({
-  label,
   type,
+  defaultOption,
   onCemeteryChange = () => {},
 }: CeremoniesDebtorsCemeterySelectProps) => {
-  const { t, i18n } = useTranslation('common', { keyPrefix: 'CemeterySelect' })
+  const { i18n } = useTranslation()
 
   // eslint-disable-next-line consistent-return
   const fetcher = useMemo(() => {
@@ -44,17 +45,12 @@ const CeremoniesDebtorsCemeterySelect = ({
     }
   }, [type, i18n.language])
 
-  const defaultOption = useMemo(() => ({ label: t('allCemeteries'), key: '' }), [t])
-
   return fetcher ? (
     <SelectWithFetcher
       swrKey={swrKey}
       defaultOption={defaultOption}
       fetcher={fetcher}
-      label={label}
-      onSelectionChange={(selection: string) => {
-        onCemeteryChange(selection)
-      }}
+      onChange={onCemeteryChange}
     />
   ) : null
 }

--- a/next/components/molecules/SelectWithFetcher.tsx
+++ b/next/components/molecules/SelectWithFetcher.tsx
@@ -1,22 +1,21 @@
 import { useMemo } from 'react'
 import useSwr, { Key } from 'swr'
 
-import Select, { Option, SelectProps, SingleSelect } from '@/components/atoms/Select'
+import Select, { SelectOption, SelectProps } from '@/components/atoms/Select'
 import { useGetSwrExtras } from '@/utils/useGetSwrExtras'
 
 type SelectWithFetcherProps = {
   swrKey: Key
-  fetcher: () => Promise<Option[]>
-  defaultOption: Option
-} & Pick<SelectProps, 'id' | 'placeholder' | 'label' | 'disabled'> &
-  Pick<SingleSelect, 'onSelectionChange'>
+  fetcher: () => Promise<SelectOption[]>
+  defaultOption: SelectOption
+} & Pick<SelectProps, 'placeholder' | 'isDisabled' | 'onChange'>
 
 const SelectWithFetcher = ({
   swrKey,
   defaultOption,
   fetcher,
-  disabled: originalDisabled,
-  onSelectionChange,
+  isDisabled: originalDisabled,
+  onChange,
   ...rest
 }: SelectWithFetcherProps) => {
   const { data, error } = useSwr(swrKey, fetcher)
@@ -34,10 +33,11 @@ const SelectWithFetcher = ({
   return (
     <Select
       options={options}
-      defaultSelected={defaultOption.key}
-      multiple={false}
-      disabled={loading || error || originalDisabled}
-      onSelectionChange={onSelectionChange}
+      defaultValue={defaultOption}
+      isDisabled={loading || error || originalDisabled}
+      onChange={(option, actionMeta) =>
+        onChange ? onChange(option?.value === 'all' ? null : option, actionMeta) : null
+      }
       {...rest}
     />
   )

--- a/next/components/molecules/SortSelect.tsx
+++ b/next/components/molecules/SortSelect.tsx
@@ -1,33 +1,27 @@
 import { useTranslation } from 'next-i18next'
 import React, { useMemo } from 'react'
 
-import Select from '@/components/atoms/Select'
+import Select, { SelectOption } from '@/components/atoms/Select'
 
 export type Sort = 'newest' | 'oldest'
 
 type SortSelectProps = {
-  defaultSelected: Sort
-  onChange?: (sort: Sort) => void
+  defaultOption: SelectOption<Sort>
+  onChange?: (option: SelectOption<Sort> | null) => void
 }
 
-const SortSelect = ({ defaultSelected, onChange = () => {} }: SortSelectProps) => {
+const SortSelect = ({ defaultOption, onChange = () => {} }: SortSelectProps) => {
   const { t } = useTranslation('common', { keyPrefix: 'SortSelect' })
 
-  const options = useMemo(
+  const options: SelectOption<Sort>[] = useMemo(
     () => [
-      { key: 'newest', label: t('byNewest') },
-      { key: 'oldest', label: t('byOldest') },
+      { value: 'newest', label: t('byNewest') },
+      { value: 'oldest', label: t('byOldest') },
     ],
     [t],
   )
 
-  return (
-    <Select
-      options={options}
-      onSelectionChange={onChange as (sort: string) => void}
-      defaultSelected={defaultSelected}
-    />
-  )
+  return <Select options={options} onChange={onChange} defaultValue={defaultOption} />
 }
 
 export default SortSelect

--- a/next/components/sections/ArticleListing/ArticleJobsCategoriesSelect.tsx
+++ b/next/components/sections/ArticleListing/ArticleJobsCategoriesSelect.tsx
@@ -1,6 +1,4 @@
-import { useTranslation } from 'next-i18next'
-import { useMemo } from 'react'
-
+import { SelectOption } from '@/components/atoms/Select'
 import SelectWithFetcher from '@/components/molecules/SelectWithFetcher'
 import {
   articleJobsCategoriesSelectFetcher,
@@ -8,24 +6,20 @@ import {
 } from '@/services/fetchers/articleListingFetcher'
 
 type ArticleJobsCategoriesSelectProps = {
-  onCategoryChange: (id: string | null) => void
+  defaultOption: SelectOption
+  onCategoryChange: (option: SelectOption | null) => void
 }
 
 const ArticleJobsCategoriesSelect = ({
+  defaultOption,
   onCategoryChange = () => {},
 }: ArticleJobsCategoriesSelectProps) => {
-  const { t } = useTranslation('common', { keyPrefix: 'ArticleListing' })
-
-  const defaultOption = useMemo(() => ({ label: t('allCategories'), key: '' }), [t])
-
   return (
     <SelectWithFetcher
       swrKey={articleJobsCategoriesSelectSwrKey}
       defaultOption={defaultOption}
       fetcher={articleJobsCategoriesSelectFetcher}
-      onSelectionChange={(selection: string) => {
-        onCategoryChange(selection === '' ? null : selection)
-      }}
+      onChange={onCategoryChange}
     />
   )
 }

--- a/next/components/sections/ArticleListing/ArticleListing.tsx
+++ b/next/components/sections/ArticleListing/ArticleListing.tsx
@@ -6,6 +6,7 @@ import { useDebounce } from 'usehooks-ts'
 
 import Loading from '@/components/atoms/Loading'
 import LoadingOverlay from '@/components/atoms/LoadingOverlay'
+import { SelectOption } from '@/components/atoms/Select'
 import ArticleCard from '@/components/molecules/Cards/ArticleCard'
 import FilteringSearchInput from '@/components/molecules/FilteringSearchInput'
 import FiltersBackgroundWrapper from '@/components/molecules/FiltersBackgroundWrapper'
@@ -146,6 +147,8 @@ type ArticleListingProps = {
 }
 
 const ArticleListing = ({ type }: ArticleListingProps) => {
+  const { t } = useTranslation('common', { keyPrefix: 'ArticleListing' })
+
   const [filters, setFilters] = useState<ArticleListingFilters>(articleListingDefaultFilters)
   const [searchInputValue, setSearchInputValue] = useState<string>('')
   const debouncedSearchInputValue = useDebounce<string>(searchInputValue, 300)
@@ -161,22 +164,45 @@ const ArticleListing = ({ type }: ArticleListingProps) => {
     setFilters({ ...filters, page })
   }
 
-  const handleCategoryChange = (categoryId: string | null) => {
-    setFilters({ ...filters, page: 1, categoryId })
+  // Selection
+
+  const defaultOption = { value: 'all', label: t('allCategories') }
+
+  const [selection, setSelection] = useState(defaultOption.value)
+
+  const handleSelectionChange = (option: SelectOption | null) => {
+    setSelection(option?.value ?? defaultOption.value)
   }
+
+  useEffect(() => {
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+      page: 1,
+      categoryId: selection === 'all' ? null : selection,
+    }))
+  }, [selection])
 
   return (
     <Section overlayWithHero>
       <FiltersBackgroundWrapper className="mb-4 grid grid-cols-1 gap-4 md:mb-6 md:grid-cols-3">
         <div>
           {type === ArticleListingType.Press ? (
-            <ArticlePressCategoriesSelect onCategoryChange={handleCategoryChange} />
+            <ArticlePressCategoriesSelect
+              defaultOption={defaultOption}
+              onCategoryChange={handleSelectionChange}
+            />
           ) : null}
           {type === ArticleListingType.News ? (
-            <ArticleNewsCategoriesSelect onCategoryChange={handleCategoryChange} />
+            <ArticleNewsCategoriesSelect
+              defaultOption={defaultOption}
+              onCategoryChange={handleSelectionChange}
+            />
           ) : null}
           {type === ArticleListingType.Jobs ? (
-            <ArticleJobsCategoriesSelect onCategoryChange={handleCategoryChange} />
+            <ArticleJobsCategoriesSelect
+              defaultOption={defaultOption}
+              onCategoryChange={handleSelectionChange}
+            />
           ) : null}
         </div>
         <div className="md:col-span-2">

--- a/next/components/sections/ArticleListing/ArticleNewsCategoriesSelect.tsx
+++ b/next/components/sections/ArticleListing/ArticleNewsCategoriesSelect.tsx
@@ -1,6 +1,4 @@
-import { useTranslation } from 'next-i18next'
-import { useMemo } from 'react'
-
+import { SelectOption } from '@/components/atoms/Select'
 import SelectWithFetcher from '@/components/molecules/SelectWithFetcher'
 import {
   articleNewsCategoriesSelectFetcher,
@@ -8,24 +6,20 @@ import {
 } from '@/services/fetchers/articleListingFetcher'
 
 type ArticleNewsCategoriesSelectProps = {
-  onCategoryChange: (id: string | null) => void
+  defaultOption: SelectOption
+  onCategoryChange: (option: SelectOption | null) => void
 }
 
 const ArticleNewsCategoriesSelect = ({
+  defaultOption,
   onCategoryChange = () => {},
 }: ArticleNewsCategoriesSelectProps) => {
-  const { t } = useTranslation('common', { keyPrefix: 'ArticleListing' })
-
-  const defaultOption = useMemo(() => ({ label: t('allCategories'), key: '' }), [t])
-
   return (
     <SelectWithFetcher
       swrKey={articleNewsCategoriesSelectSwrKey}
       defaultOption={defaultOption}
       fetcher={articleNewsCategoriesSelectFetcher}
-      onSelectionChange={(selection: string) => {
-        onCategoryChange(selection === '' ? null : selection)
-      }}
+      onChange={onCategoryChange}
     />
   )
 }

--- a/next/components/sections/ArticleListing/ArticlePressCategoriesSelect.tsx
+++ b/next/components/sections/ArticleListing/ArticlePressCategoriesSelect.tsx
@@ -1,6 +1,4 @@
-import { useTranslation } from 'next-i18next'
-import { useMemo } from 'react'
-
+import { SelectOption } from '@/components/atoms/Select'
 import SelectWithFetcher from '@/components/molecules/SelectWithFetcher'
 import {
   articlePressCategoriesSelectFetcher,
@@ -8,24 +6,20 @@ import {
 } from '@/services/fetchers/articleListingFetcher'
 
 type ArticlePressCategoriesSelectProps = {
-  onCategoryChange: (id: string | null) => void
+  defaultOption: SelectOption
+  onCategoryChange: (option: SelectOption | null) => void
 }
 
 const ArticlePressCategoriesSelect = ({
+  defaultOption,
   onCategoryChange = () => {},
 }: ArticlePressCategoriesSelectProps) => {
-  const { t } = useTranslation('common', { keyPrefix: 'ArticleListing' })
-
-  const defaultOption = useMemo(() => ({ label: t('allCategories'), key: '' }), [t])
-
   return (
     <SelectWithFetcher
       swrKey={articlePressCategoriesSelectSwrKey}
       defaultOption={defaultOption}
       fetcher={articlePressCategoriesSelectFetcher}
-      onSelectionChange={(selection: string) => {
-        onCategoryChange(selection === '' ? null : selection)
-      }}
+      onChange={onCategoryChange}
     />
   )
 }

--- a/next/components/sections/CeremoniesArchiveSection.tsx
+++ b/next/components/sections/CeremoniesArchiveSection.tsx
@@ -8,6 +8,7 @@ import { useDebounce } from 'usehooks-ts'
 import FormatDate from '@/components/atoms/FormatDate'
 import Loading from '@/components/atoms/Loading'
 import LoadingOverlay from '@/components/atoms/LoadingOverlay'
+import { SelectOption } from '@/components/atoms/Select'
 import CemeteryLink from '@/components/molecules/CemeteryLink'
 import CeremoniesDebtorsCemeterySelect from '@/components/molecules/CeremoniesDebtors/CemeterySelect'
 import FilteringSearchInput from '@/components/molecules/FilteringSearchInput'
@@ -166,11 +167,32 @@ const DataWrapper = ({
 }
 
 const CeremoniesArchiveSection = () => {
+  const { t } = useTranslation('common', { keyPrefix: 'CemeterySelect' })
+
   const [filters, setFilters] = useState<CeremoniesArchiveSectionFilters>(
     ceremoniesArchiveSectionDefaultFilters,
   )
   const [searchInputValue, setSearchInputValue] = useState<string>('')
   const debouncedSearchInputValue = useDebounce<string>(searchInputValue, 300)
+
+  // Selection
+
+  const defaultOption = { value: 'all', label: t('allCemeteries') }
+
+  const [selection, setSelection] = useState(defaultOption.value)
+
+  const handleSelectionChange = (option: SelectOption | null) => {
+    setSelection(option?.value ?? defaultOption.value)
+  }
+
+  useEffect(() => {
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+      cemeteryId: selection === 'all' ? null : selection,
+    }))
+  }, [selection])
+
+  // Search
 
   useEffect(() => {
     if (filters.search !== debouncedSearchInputValue) {
@@ -186,17 +208,14 @@ const CeremoniesArchiveSection = () => {
     setFilters({ ...filters, page })
   }
 
-  const handleCemeteryChange = (cemeteryId: string) => {
-    setFilters({ ...filters, cemeteryId })
-  }
-
   return (
     <Section overlayWithHero>
       <FiltersBackgroundWrapper className="mb-4 grid grid-cols-1 gap-4 md:mb-6 md:grid-cols-3">
         <div>
           <CeremoniesDebtorsCemeterySelect
             type="ceremonies"
-            onCemeteryChange={handleCemeteryChange}
+            defaultOption={defaultOption}
+            onCemeteryChange={handleSelectionChange}
           />
         </div>
         <div className="md:col-span-2">

--- a/next/components/sections/CeremoniesSection.tsx
+++ b/next/components/sections/CeremoniesSection.tsx
@@ -3,13 +3,14 @@ import cx from 'classnames'
 import groupBy from 'lodash/groupBy'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-import { Fragment, PropsWithChildren, useMemo, useRef, useState } from 'react'
+import { Fragment, PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react'
 import useSwr from 'swr'
 
 import FormatDate from '@/components/atoms/FormatDate'
 import Loading from '@/components/atoms/Loading'
 import LoadingOverlay from '@/components/atoms/LoadingOverlay'
 import MLink from '@/components/atoms/MLink'
+import { SelectOption } from '@/components/atoms/Select'
 import CemeteryLink from '@/components/molecules/CemeteryLink'
 import CeremoniesDebtorsCemeterySelect from '@/components/molecules/CeremoniesDebtors/CemeterySelect'
 import { useGetFullPath } from '@/components/molecules/Navigation/NavigationProvider/useGetFullPath'
@@ -226,21 +227,34 @@ type CeremoniesSectionProps = {
 }
 
 const CeremoniesSection = ({ section }: CeremoniesSectionProps) => {
-  const { t } = useTranslation('common', { keyPrefix: 'CeremoniesSection' })
+  const { t } = useTranslation('common', { keyPrefix: 'CemeterySelect' })
 
   const [filters, setFilters] = useState<CeremoniesSectionFilters>(ceremoniesSectionDefaultFilters)
 
-  const handleCemeteryChange = (cemeteryId: string) => {
-    setFilters({ ...filters, cemeteryId })
+  // Selection
+
+  const defaultOption = { value: 'all', label: t('allCemeteries') }
+
+  const [selection, setSelection] = useState(defaultOption.value)
+
+  const handleSelectionChange = (option: SelectOption | null) => {
+    setSelection(option?.value ?? defaultOption.value)
   }
+
+  useEffect(() => {
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+      cemeteryId: selection === 'all' ? null : selection,
+    }))
+  }, [selection])
 
   return (
     <Section>
       <div className="mb-6 md:mb-8 md:w-[360px]">
         <CeremoniesDebtorsCemeterySelect
-          label={t('filterBy')}
           type="ceremonies"
-          onCemeteryChange={handleCemeteryChange}
+          defaultOption={defaultOption}
+          onCemeteryChange={handleSelectionChange}
         />
       </div>
 

--- a/next/components/sections/DebtorsSection.tsx
+++ b/next/components/sections/DebtorsSection.tsx
@@ -7,6 +7,7 @@ import { useDebounce } from 'usehooks-ts'
 
 import Loading from '@/components/atoms/Loading'
 import LoadingOverlay from '@/components/atoms/LoadingOverlay'
+import { SelectOption } from '@/components/atoms/Select'
 import CemeteryLink from '@/components/molecules/CemeteryLink'
 import CeremoniesDebtorsCemeterySelect from '@/components/molecules/CeremoniesDebtors/CemeterySelect'
 import FilteringSearchInput from '@/components/molecules/FilteringSearchInput'
@@ -155,6 +156,8 @@ type DebtorsSectionProps = {
 }
 
 const DebtorsSection = ({ description }: DebtorsSectionProps) => {
+  const { t } = useTranslation('common', { keyPrefix: 'CemeterySelect' })
+
   const [filters, setFilters] = useState<DebtorsSectionFilters>(debtorsSectionDefaultFilters)
   const [searchInputValue, setSearchInputValue] = useState<string>('')
   const debouncedSearchInputValue = useDebounce<string>(searchInputValue, 300)
@@ -170,15 +173,33 @@ const DebtorsSection = ({ description }: DebtorsSectionProps) => {
     setFilters({ ...filters, page })
   }
 
-  const handleCemeteryChange = (cemeteryId: string) => {
-    setFilters({ ...filters, page: 1, cemeteryId })
+  // Selection
+
+  const defaultOption = { value: 'all', label: t('allCemeteries') }
+
+  const [selection, setSelection] = useState(defaultOption.value)
+
+  const handleSelectionChange = (option: SelectOption | null) => {
+    setSelection(option?.value ?? defaultOption.value)
   }
+
+  useEffect(() => {
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+      page: 1,
+      cemeteryId: selection === 'all' ? null : selection,
+    }))
+  }, [selection])
 
   return (
     <Section overlayWithHero>
       <FiltersBackgroundWrapper className="mb-4 grid grid-cols-1 gap-4 md:mb-6 md:grid-cols-3">
         <div>
-          <CeremoniesDebtorsCemeterySelect type="debtors" onCemeteryChange={handleCemeteryChange} />
+          <CeremoniesDebtorsCemeterySelect
+            type="debtors"
+            defaultOption={defaultOption}
+            onCemeteryChange={handleSelectionChange}
+          />
         </div>
         <div className="md:col-span-2">
           <FilteringSearchInput

--- a/next/components/sections/DisclosuresSection.tsx
+++ b/next/components/sections/DisclosuresSection.tsx
@@ -10,7 +10,7 @@ import FormatDate from '@/components/atoms/FormatDate'
 import IconButton from '@/components/atoms/IconButton'
 import Loading from '@/components/atoms/Loading'
 import LoadingOverlay from '@/components/atoms/LoadingOverlay'
-import Select from '@/components/atoms/Select'
+import Select, { SelectOption } from '@/components/atoms/Select'
 import FilteringSearchInput from '@/components/molecules/FilteringSearchInput'
 import FiltersBackgroundWrapper from '@/components/molecules/FiltersBackgroundWrapper'
 import PaginationMeili from '@/components/molecules/PaginationMeili'
@@ -192,42 +192,40 @@ const DataWrapper = ({
   )
 }
 
-const TypeSelect = ({
-  onTypeChange,
-}: {
-  onTypeChange: (type: DisclosureTypeFixed | null) => void
-}) => {
+type TypeSelectProps = {
+  defaultOption: SelectOption
+  onTypeChange: (option: SelectOption | null) => void
+}
+
+const TypeSelect = ({ defaultOption, onTypeChange }: TypeSelectProps) => {
   const { t } = useTranslation('common', { keyPrefix: 'DisclosuresSection' })
 
   return (
     <Select
-      defaultSelected="all"
+      defaultValue={defaultOption}
       options={[
+        defaultOption,
         {
-          key: 'all',
-          label: t('types.all'),
-        },
-        {
-          key: DisclosureTypeFixed.Faktura,
+          value: DisclosureTypeFixed.Faktura,
           label: t('types.faktury'),
         },
         {
-          key: DisclosureTypeFixed.Zmluva,
+          value: DisclosureTypeFixed.Zmluva,
           label: t('types.zmluvy'),
         },
         {
-          key: DisclosureTypeFixed.Objednavka,
+          value: DisclosureTypeFixed.Objednavka,
           label: t('types.objednavky'),
         },
       ]}
-      onSelectionChange={(type) => {
-        onTypeChange(type === 'all' ? null : (type as DisclosureTypeFixed))
-      }}
+      onChange={(option) => onTypeChange(option?.value === 'all' ? null : option)}
     />
   )
 }
 
 const DisclosuresSection = () => {
+  const { t } = useTranslation('common', { keyPrefix: 'DisclosuresSection' })
+
   const [filters, setFilters] = useState<DisclosuresSectionFilters>(
     disclosuresSectionDefaultFilters,
   )
@@ -245,15 +243,29 @@ const DisclosuresSection = () => {
     setFilters({ ...filters, page })
   }
 
-  const handleTypeChange = (type: DisclosureTypeFixed | null) => {
-    setFilters({ ...filters, page: 1, type })
+  // Selection
+
+  const defaultOption = { value: 'all', label: t('types.all') }
+
+  const [selection, setSelection] = useState(defaultOption.value)
+
+  const handleSelectionChange = (option: SelectOption | null) => {
+    setSelection(option?.value ?? defaultOption.value)
   }
+
+  useEffect(() => {
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+      page: 1,
+      type: selection === 'all' ? null : (selection as DisclosureTypeFixed),
+    }))
+  }, [selection])
 
   return (
     <Section overlayWithHero>
       <FiltersBackgroundWrapper className="mb-4 grid grid-cols-1 gap-4 md:mb-6 md:grid-cols-3">
         <div>
-          <TypeSelect onTypeChange={handleTypeChange} />
+          <TypeSelect defaultOption={defaultOption} onTypeChange={handleSelectionChange} />
         </div>
         <div className="md:col-span-2">
           <FilteringSearchInput

--- a/next/components/sections/DocumentsSection/DocumentsSection.tsx
+++ b/next/components/sections/DocumentsSection/DocumentsSection.tsx
@@ -8,6 +8,7 @@ import { DownloadIcon } from '@/assets/icons'
 import Button from '@/components/atoms/Button'
 import Loading from '@/components/atoms/Loading'
 import LoadingOverlay from '@/components/atoms/LoadingOverlay'
+import { SelectOption } from '@/components/atoms/Select'
 import FilteringSearchInput from '@/components/molecules/FilteringSearchInput'
 import FiltersBackgroundWrapper from '@/components/molecules/FiltersBackgroundWrapper'
 import { useGetFullPathMeili } from '@/components/molecules/Navigation/NavigationProvider/useGetFullPath'
@@ -138,6 +139,8 @@ type DocumentsSectionProps = {
 }
 
 const DocumentsSection = ({ description }: DocumentsSectionProps) => {
+  const { t } = useTranslation('common')
+
   const [filters, setFilters] = useState<DocumentsSectionFilters>(documentsSectionDefaultFilters)
   const [searchInputValue, setSearchInputValue] = useState<string>('')
   const debouncedSearchInputValue = useDebounce<string>(searchInputValue, 300)
@@ -153,17 +156,47 @@ const DocumentsSection = ({ description }: DocumentsSectionProps) => {
     setFilters({ ...filters, page })
   }
 
-  const handleCategoryChange = (categoryId: string | null) => {
-    setFilters({ ...filters, page: 1, categoryId })
+  // Selection
+
+  const defaultCategoryOption = { value: 'all', label: t('DocumentsSection.allCategories') }
+  const defaultFiletypeOption = { value: 'all', label: t('DocumentsSection.allFileTypes') }
+  const defaultSortOption: SelectOption<Sort> = { value: 'newest', label: t('SortSelect.byNewest') }
+
+  const [categorySelection, setCategorySelection] = useState(defaultCategoryOption.value)
+  const [filetypeSelection, setFiletypeSelection] = useState(defaultFiletypeOption.value)
+  const [sortSelection, setSortSelection] = useState<Sort>(defaultSortOption.value)
+
+  const handleCategoryChange = (option: SelectOption | null) => {
+    setCategorySelection(option?.value ?? defaultCategoryOption.value)
   }
 
-  const handleFiletypeChange = (filetype: string | null) => {
-    setFilters({ ...filters, page: 1, filetype })
+  const handleFiletypeChange = (option: SelectOption | null) => {
+    setFiletypeSelection(option?.value ?? defaultFiletypeOption.value)
   }
 
-  const handleSortChange = (sort: Sort) => {
-    setFilters({ ...filters, sort })
+  const handleSortChange = (option: SelectOption<Sort> | null) => {
+    setSortSelection(option?.value ?? defaultSortOption.value)
   }
+
+  useEffect(() => {
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+      page: 1,
+      categoryId: categorySelection === 'all' ? null : categorySelection,
+    }))
+  }, [categorySelection])
+
+  useEffect(() => {
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+      page: 1,
+      filetype: filetypeSelection === 'all' ? null : filetypeSelection,
+    }))
+  }, [filetypeSelection])
+
+  useEffect(() => {
+    setFilters((prevFilters) => ({ ...prevFilters, sort: sortSelection }))
+  }, [sortSelection])
 
   return (
     <Section overlayWithHero>
@@ -174,9 +207,15 @@ const DocumentsSection = ({ description }: DocumentsSectionProps) => {
             onChange={(value) => setSearchInputValue(value)}
           />
         </div>
-        <DocumentsSectionCategorySelect onCategoryChange={handleCategoryChange} />
-        <DocumentsSectionFiletypeSelect onFiletypeChange={handleFiletypeChange} />
-        <SortSelect onChange={handleSortChange} defaultSelected={filters.sort} />
+        <DocumentsSectionCategorySelect
+          defaultOption={defaultCategoryOption}
+          onCategoryChange={handleCategoryChange}
+        />
+        <DocumentsSectionFiletypeSelect
+          defaultOption={defaultFiletypeOption}
+          onFiletypeChange={handleFiletypeChange}
+        />
+        <SortSelect defaultOption={defaultSortOption} onChange={handleSortChange} />
       </FiltersBackgroundWrapper>
 
       <div>

--- a/next/components/sections/DocumentsSection/DocumentsSectionCategorySelect.tsx
+++ b/next/components/sections/DocumentsSection/DocumentsSectionCategorySelect.tsx
@@ -1,38 +1,32 @@
-import { useTranslation } from 'next-i18next'
-import { useMemo } from 'react'
-
+import { SelectOption } from '@/components/atoms/Select'
 import SelectWithFetcher from '@/components/molecules/SelectWithFetcher'
 import { client } from '@/services/graphql/gqlClient'
 
 type DocumentsSectionCategorySelectProps = {
-  onCategoryChange: (id: string | null) => void
+  defaultOption: SelectOption
+  onCategoryChange: (option: SelectOption | null) => void
 }
 
 const mappedFetcher = () =>
   client.DocumentCategories().then(
     (data) =>
       data.documentCategories?.data.map((category) => ({
-        label: category.attributes?.title,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        key: category.id!,
+        value: category.id!,
+        label: category?.attributes?.title ?? '',
       })) ?? [],
   )
 
 const DocumentsSectionCategorySelect = ({
+  defaultOption,
   onCategoryChange = () => {},
 }: DocumentsSectionCategorySelectProps) => {
-  const { t } = useTranslation('common', { keyPrefix: 'DocumentsSection' })
-
-  const defaultOption = useMemo(() => ({ label: t('allCategories'), key: '' }), [t])
-
   return (
     <SelectWithFetcher
       swrKey="DocumentsSectionCategorySelect"
       defaultOption={defaultOption}
       fetcher={mappedFetcher}
-      onSelectionChange={(selection: string) => {
-        onCategoryChange(selection === '' ? null : selection)
-      }}
+      onChange={onCategoryChange}
     />
   )
 }

--- a/next/components/sections/DocumentsSection/DocumentsSectionFiletypeSelect.tsx
+++ b/next/components/sections/DocumentsSection/DocumentsSectionFiletypeSelect.tsx
@@ -1,38 +1,32 @@
-import { useTranslation } from 'next-i18next'
-import { useMemo } from 'react'
-
+import { SelectOption } from '@/components/atoms/Select'
 import SelectWithFetcher from '@/components/molecules/SelectWithFetcher'
 import { client } from '@/services/graphql/gqlClient'
 import { isDefined } from '@/utils/isDefined'
 
 type DocumentsSectionFiletypeSelectProps = {
-  onFiletypeChange: (filetype: string | null) => void
+  defaultOption: SelectOption
+  onFiletypeChange: (option: SelectOption | null) => void
 }
 
 const mappedFetcher = () =>
   client.DocumentFiletypes().then(
     (data) =>
       data.documentFiletypes?.filter(isDefined).map((filetype) => ({
+        value: filetype,
         label: (filetype.startsWith('.') ? filetype.slice(1) : filetype).toUpperCase(),
-        key: filetype,
       })) ?? [],
   )
 
 const DocumentsSectionFiletypeSelect = ({
+  defaultOption,
   onFiletypeChange = () => {},
 }: DocumentsSectionFiletypeSelectProps) => {
-  const { t } = useTranslation('common', { keyPrefix: 'DocumentsSection' })
-
-  const defaultOption = useMemo(() => ({ label: t('allFileTypes'), key: '' }), [t])
-
   return (
     <SelectWithFetcher
       swrKey="DocumentsSectionFiletypeSelect"
       defaultOption={defaultOption}
       fetcher={mappedFetcher}
-      onSelectionChange={(selection: string) => {
-        onFiletypeChange(selection === '' ? null : selection)
-      }}
+      onChange={onFiletypeChange}
     />
   )
 }

--- a/next/package.json
+++ b/next/package.json
@@ -20,7 +20,6 @@
     "update-graphql": "yarn add graphql@latest graphql-request@latest graphql-tag@latest --exact && yarn add @graphql-codegen/cli@latest @graphql-codegen/typescript-graphql-request@latest --dev --exact"
   },
   "dependencies": {
-    "@headlessui/react": "^1.6.6",
     "@hookform/error-message": "^2.0.0",
     "@hookform/resolvers": "^2.9.10",
     "@internationalized/date": "^3.0.1",
@@ -52,8 +51,8 @@
     "react-hook-form": "^7.39.1",
     "react-map-gl": "^7.0.19",
     "react-markdown": "^8.0.3",
-    "react-popper": "^2.3.0",
     "react-resize-detector": "^7.1.2",
+    "react-select": "^5.10.0",
     "react-stately": "^3.16.0",
     "react-turnstile": "^1.0.6",
     "rehype-raw": "^6.1.1",

--- a/next/pages/styleguide.tsx
+++ b/next/pages/styleguide.tsx
@@ -842,21 +842,18 @@ const Showcase = () => {
           <Wrapper title="Select">
             <Stack width="full">
               <Select
-                label="Project"
-                required
-                id="select"
                 placeholder="Select one project"
                 options={[
                   {
-                    key: 'marianum',
+                    value: 'marianum',
                     label: '💀 Marianum',
                   },
                   {
-                    key: 'city-library',
+                    value: 'city-library',
                     label: '📖 City library',
                   },
                   {
-                    key: 'homepage',
+                    value: 'homepage',
                     label: '🟥 Homepage',
                   },
                 ]}
@@ -864,22 +861,19 @@ const Showcase = () => {
             </Stack>
             <Stack width="full">
               <Select
-                label="Projects"
-                required
-                id="select"
-                multiple
+                // TODO - isMulti is temporarily disabled, because it is not yet implemented in the component
                 placeholder="Select multiple projects"
                 options={[
                   {
-                    key: 'marianum',
+                    value: 'marianum',
                     label: '💀 Marianum',
                   },
                   {
-                    key: 'city-library',
+                    value: 'city-library',
                     label: '📖 City library',
                   },
                   {
-                    key: 'homepage',
+                    value: 'homepage',
                     label: '🟥 Homepage',
                   },
                 ]}

--- a/next/services/fetchers/articleListingFetcher.ts
+++ b/next/services/fetchers/articleListingFetcher.ts
@@ -1,6 +1,6 @@
 import { Key } from 'swr'
 
-import { Option } from '@/components/atoms/Select'
+import { SelectOption } from '@/components/atoms/Select'
 import { client } from '@/services/graphql/gqlClient'
 import { meiliClient } from '@/services/meili/meiliClient'
 import { ArticleMeili } from '@/services/meili/meiliTypes'
@@ -76,9 +76,9 @@ const mapSelectFn = (category: {
   id?: string | null
 }) =>
   ({
+    value: category.id,
     label: category.attributes?.title,
-    key: category.id,
-  }) as Option
+  }) as SelectOption
 
 export const articleNewsCategoriesSelectSwrKey = 'ArticleNewsCategoriesSelect'
 export const articleNewsCategoriesSelectFetcher = () =>

--- a/next/services/fetchers/ceremoniesSectionFetcher.ts
+++ b/next/services/fetchers/ceremoniesSectionFetcher.ts
@@ -1,7 +1,7 @@
 import { parseAbsolute } from '@internationalized/date'
 import { Key } from 'swr'
 
-import { Option } from '@/components/atoms/Select'
+import { SelectOption } from '@/components/atoms/Select'
 import { client } from '@/services/graphql/gqlClient'
 import { bratislavaTimezone } from '@/utils/consts'
 import { getCemeteryInfoInCeremoniesDebtors } from '@/utils/getCemeteryInfoInCeremoniesDebtors'
@@ -38,11 +38,11 @@ export const cemeteriesInCeremoniesFetcher = async (locale: string) => {
     result.cemeteries?.data?.map(
       (cemetery) =>
         ({
-          label: getCemeteryInfoInCeremoniesDebtors(cemetery, locale).title ?? '',
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          key: cemetery.id!,
-        }) as Option,
-    ) ?? ([] as Option[])
+          value: cemetery.id!,
+          label: getCemeteryInfoInCeremoniesDebtors(cemetery, locale).title ?? '',
+        }) as SelectOption,
+    ) ?? ([] as SelectOption[])
   )
 }
 

--- a/next/services/fetchers/debtorsSectionFetcher.ts
+++ b/next/services/fetchers/debtorsSectionFetcher.ts
@@ -1,6 +1,6 @@
 import { Key } from 'swr'
 
-import { Option } from '@/components/atoms/Select'
+import { SelectOption } from '@/components/atoms/Select'
 import { client } from '@/services/graphql/gqlClient'
 import { meiliClient } from '@/services/meili/meiliClient'
 import { DebtorMeili } from '@/services/meili/meiliTypes'
@@ -39,11 +39,11 @@ export const cemeteriesInDebtorsFetcher = async (locale: string) => {
     result.cemeteries?.data?.map(
       (cemetery) =>
         ({
-          label: getCemeteryInfoInCeremoniesDebtors(cemetery, locale).title ?? '',
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          key: cemetery.id!,
-        }) as Option,
-    ) ?? ([] as Option[])
+          value: cemetery.id!,
+          label: getCemeteryInfoInCeremoniesDebtors(cemetery, locale).title ?? '',
+        }) as SelectOption,
+    ) ?? ([] as SelectOption[])
   )
 }
 

--- a/next/styles/globals.css
+++ b/next/styles/globals.css
@@ -8,36 +8,40 @@
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 400;
-    src: local(''),
-    url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff2') format('woff2'),
-    url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff') format('woff');
+    src:
+      local(''),
+      url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff2') format('woff2'),
+      url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff') format('woff');
   }
   /* noto-sans-600 - latin-ext_latin */
   @font-face {
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 600;
-    src: local(''),
-    url('/fonts/noto-sans-v27-latin-ext_latin-600.woff2') format('woff2'),
-    url('/fonts/noto-sans-v27-latin-ext_latin-600.woff') format('woff');
+    src:
+      local(''),
+      url('/fonts/noto-sans-v27-latin-ext_latin-600.woff2') format('woff2'),
+      url('/fonts/noto-sans-v27-latin-ext_latin-600.woff') format('woff');
   }
   /* noto-sans-700 - latin-ext_latin */
   @font-face {
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 700;
-    src: local(''),
-    url('/fonts/noto-sans-v27-latin-ext_latin-700.woff2') format('woff2'),
-    url('/fonts/noto-sans-v27-latin-ext_latin-700.woff') format('woff');
+    src:
+      local(''),
+      url('/fonts/noto-sans-v27-latin-ext_latin-700.woff2') format('woff2'),
+      url('/fonts/noto-sans-v27-latin-ext_latin-700.woff') format('woff');
   }
   /* ABCArizonaFlare-Bold */
   @font-face {
     font-family: 'ABC Arizona Flare';
     font-style: normal;
     font-weight: 700;
-    src: local(''),
-    url('/fonts/ABCArizonaFlare-Bold.woff2') format('woff2'),
-    url('/fonts/ABCArizonaFlare-Bold.woff') format('woff');
+    src:
+      local(''),
+      url('/fonts/ABCArizonaFlare-Bold.woff2') format('woff2'),
+      url('/fonts/ABCArizonaFlare-Bold.woff') format('woff');
   }
 
   @supports (-webkit-text-stroke: 4px #446650) {

--- a/next/styles/globals.css
+++ b/next/styles/globals.css
@@ -8,40 +8,36 @@
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 400;
-    src:
-      local(''),
-      url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff2') format('woff2'),
-      url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff') format('woff');
+    src: local(''),
+    url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff2') format('woff2'),
+    url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff') format('woff');
   }
   /* noto-sans-600 - latin-ext_latin */
   @font-face {
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 600;
-    src:
-      local(''),
-      url('/fonts/noto-sans-v27-latin-ext_latin-600.woff2') format('woff2'),
-      url('/fonts/noto-sans-v27-latin-ext_latin-600.woff') format('woff');
+    src: local(''),
+    url('/fonts/noto-sans-v27-latin-ext_latin-600.woff2') format('woff2'),
+    url('/fonts/noto-sans-v27-latin-ext_latin-600.woff') format('woff');
   }
   /* noto-sans-700 - latin-ext_latin */
   @font-face {
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 700;
-    src:
-      local(''),
-      url('/fonts/noto-sans-v27-latin-ext_latin-700.woff2') format('woff2'),
-      url('/fonts/noto-sans-v27-latin-ext_latin-700.woff') format('woff');
+    src: local(''),
+    url('/fonts/noto-sans-v27-latin-ext_latin-700.woff2') format('woff2'),
+    url('/fonts/noto-sans-v27-latin-ext_latin-700.woff') format('woff');
   }
   /* ABCArizonaFlare-Bold */
   @font-face {
     font-family: 'ABC Arizona Flare';
     font-style: normal;
     font-weight: 700;
-    src:
-      local(''),
-      url('/fonts/ABCArizonaFlare-Bold.woff2') format('woff2'),
-      url('/fonts/ABCArizonaFlare-Bold.woff') format('woff');
+    src: local(''),
+    url('/fonts/ABCArizonaFlare-Bold.woff2') format('woff2'),
+    url('/fonts/ABCArizonaFlare-Bold.woff') format('woff');
   }
 
   @supports (-webkit-text-stroke: 4px #446650) {
@@ -65,9 +61,9 @@
   */
   html,
   body,
-  /* next main div */
+    /* next main div */
   #__next,
-  /* <OverlayProvider /> from react-aria */
+    /* <OverlayProvider /> from react-aria */
   #__next > [data-overlay-container='true'] {
     @apply h-full;
   }
@@ -223,4 +219,13 @@
 .full-width-canvas-page canvas {
   width: 100% !important;
   height: auto !important;
+}
+
+/* Remove native Safari arrows in accordions  */
+details > summary {
+  list-style: none;
+}
+
+details > summary::-webkit-details-marker {
+  display: none;
 }

--- a/next/yarn.lock
+++ b/next/yarn.lock
@@ -166,6 +166,15 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
+"@babel/code-frame@^7.26.2":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
+  integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.25.9"
+    js-tokens "^4.0.0"
+    picocolors "^1.0.0"
+
 "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.5", "@babel/compat-data@^7.21.5":
   version "7.21.9"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.21.9.tgz#10a2e7fda4e51742c907938ac3b7229426515514"
@@ -201,6 +210,17 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
+
+"@babel/generator@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.9.tgz#75a9482ad3d0cc7188a537aa4910bc59db67cbca"
+  integrity sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==
+  dependencies:
+    "@babel/parser" "^7.26.9"
+    "@babel/types" "^7.26.9"
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jsesc "^3.0.2"
 
 "@babel/helper-annotate-as-pure@^7.18.6":
   version "7.18.6"
@@ -290,6 +310,14 @@
   dependencies:
     "@babel/types" "^7.21.5"
 
+"@babel/helper-module-imports@^7.16.7":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz#e7f8d20602ebdbf9ebbea0a0751fb0f2a4141715"
+  integrity sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==
+  dependencies:
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.25.9"
+
 "@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@^7.21.4":
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz#ac88b2f76093637489e718a90cec6cf8a9b029af"
@@ -371,6 +399,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz#2b3eea65443c6bdc31c22d037c65f6d323b6b2bd"
   integrity sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==
 
+"@babel/helper-string-parser@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
+  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
+
 "@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
@@ -380,6 +413,11 @@
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
   integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
+
+"@babel/helper-validator-identifier@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
+  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
 "@babel/helper-validator-option@^7.18.6", "@babel/helper-validator-option@^7.21.0":
   version "7.21.0"
@@ -418,6 +456,13 @@
   version "7.21.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.9.tgz#ab18ea3b85b4bc33ba98a8d4c2032c557d23cf14"
   integrity sha512-q5PNg/Bi1OpGgx5jYlvWZwAorZepEudDMCLtj967aeS7WMont7dUZI46M2XwcIQqvUlMxWfdLFu4S/qSxeUu5g==
+
+"@babel/parser@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.9.tgz#d9e78bee6dc80f9efd8f2349dcfbbcdace280fd5"
+  integrity sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==
+  dependencies:
+    "@babel/types" "^7.26.9"
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1134,6 +1179,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.9.tgz#aa4c6facc65b9cb3f87d75125ffd47781b475433"
+  integrity sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7":
   version "7.21.9"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.21.9.tgz#bf8dad2859130ae46088a99c1f265394877446fb"
@@ -1142,6 +1194,15 @@
     "@babel/code-frame" "^7.21.4"
     "@babel/parser" "^7.21.9"
     "@babel/types" "^7.21.5"
+
+"@babel/template@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.26.9.tgz#4577ad3ddf43d194528cff4e1fa6b232fa609bb2"
+  integrity sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/parser" "^7.26.9"
+    "@babel/types" "^7.26.9"
 
 "@babel/traverse@^7.14.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.20.5", "@babel/traverse@^7.21.5", "@babel/traverse@^7.7.0":
   version "7.21.5"
@@ -1159,6 +1220,19 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.25.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.9.tgz#4398f2394ba66d05d988b2ad13c219a2c857461a"
+  integrity sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/generator" "^7.26.9"
+    "@babel/parser" "^7.26.9"
+    "@babel/template" "^7.26.9"
+    "@babel/types" "^7.26.9"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.16.8", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.20.0", "@babel/types@^7.20.5", "@babel/types@^7.21.0", "@babel/types@^7.21.4", "@babel/types@^7.21.5", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.5.tgz#18dfbd47c39d3904d5db3d3dc2cc80bedb60e5b6"
@@ -1168,12 +1242,53 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.25.9", "@babel/types@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.9.tgz#08b43dec79ee8e682c2ac631c010bdcac54a21ce"
+  integrity sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==
+  dependencies:
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
+
+"@emotion/babel-plugin@^11.13.5":
+  version "11.13.5"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz#eab8d65dbded74e0ecfd28dc218e75607c4e7bc0"
+  integrity sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/serialize" "^1.3.3"
+    babel-plugin-macros "^3.1.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.2.0"
+
+"@emotion/cache@^11.14.0", "@emotion/cache@^11.4.0":
+  version "11.14.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.14.0.tgz#ee44b26986eeb93c8be82bb92f1f7a9b21b2ed76"
+  integrity sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==
+  dependencies:
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/sheet" "^1.4.0"
+    "@emotion/utils" "^1.4.2"
+    "@emotion/weak-memoize" "^0.4.0"
+    stylis "4.2.0"
+
+"@emotion/hash@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
+  integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
 
 "@emotion/is-prop-valid@^0.8.2":
   version "0.8.8"
@@ -1186,6 +1301,61 @@
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/memoize@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.9.0.tgz#745969d649977776b43fc7648c556aaa462b4102"
+  integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
+
+"@emotion/react@^11.8.1":
+  version "11.14.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.14.0.tgz#cfaae35ebc67dd9ef4ea2e9acc6cd29e157dd05d"
+  integrity sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.13.5"
+    "@emotion/cache" "^11.14.0"
+    "@emotion/serialize" "^1.3.3"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.2.0"
+    "@emotion/utils" "^1.4.2"
+    "@emotion/weak-memoize" "^0.4.0"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.3.3.tgz#d291531005f17d704d0463a032fe679f376509e8"
+  integrity sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==
+  dependencies:
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/unitless" "^0.10.0"
+    "@emotion/utils" "^1.4.2"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.4.0.tgz#c9299c34d248bc26e82563735f78953d2efca83c"
+  integrity sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
+
+"@emotion/unitless@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
+  integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
+
+"@emotion/use-insertion-effect-with-fallbacks@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz#8a8cb77b590e09affb960f4ff1e9a89e532738bf"
+  integrity sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==
+
+"@emotion/utils@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.4.2.tgz#6df6c45881fcb1c412d6688a311a98b7f59c1b52"
+  integrity sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==
+
+"@emotion/weak-memoize@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
+  integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -1254,12 +1424,27 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-0.7.3.tgz#d274116678ffae87f6b60e90f88cc4083eefab86"
   integrity sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.9.tgz#64d1da251433019dafa091de9b2886ff35ec14e6"
+  integrity sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==
+  dependencies:
+    "@floating-ui/utils" "^0.2.9"
+
 "@floating-ui/dom@^0.5.3":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-0.5.4.tgz#4eae73f78bcd4bd553ae2ade30e6f1f9c73fe3f1"
   integrity sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==
   dependencies:
     "@floating-ui/core" "^0.7.3"
+
+"@floating-ui/dom@^1.0.1":
+  version "1.6.13"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.13.tgz#a8a938532aea27a95121ec16e667a7cbe8c59e34"
+  integrity sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.9"
 
 "@floating-ui/react-dom@0.7.2":
   version "0.7.2"
@@ -1268,6 +1453,11 @@
   dependencies:
     "@floating-ui/dom" "^0.5.3"
     use-isomorphic-layout-effect "^1.1.1"
+
+"@floating-ui/utils@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
+  integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
 
 "@formatjs/ecma402-abstract@1.15.0":
   version "1.15.0"
@@ -1734,13 +1924,6 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@headlessui/react@^1.6.6":
-  version "1.7.14"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.14.tgz#75f19552c535113640fe8a3a40e71474f49e89c9"
-  integrity sha512-znzdq9PG8rkwcu9oQ2FwIy0ZFtP9Z7ycS+BAqJ3R5EIqC/0bJGvhT7193rFf+45i9nnPsYvCQVW4V/bB9Xc+gA==
-  dependencies:
-    client-only "^0.0.1"
-
 "@hookform/error-message@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@hookform/error-message/-/error-message-2.0.1.tgz#6a37419106e13664ad6a29c9dae699ae6cd276b8"
@@ -1829,6 +2012,15 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz#4f0e06362e01362f823d348f1872b08f666d8142"
+  integrity sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==
+  dependencies:
+    "@jridgewell/set-array" "^1.2.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@jridgewell/resolve-uri@3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
@@ -1839,10 +2031,20 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
   integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
 
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
 "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/set-array@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
+  integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
 "@jridgewell/sourcemap-codec@1.4.14":
   version "1.4.14"
@@ -1853,6 +2055,11 @@
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/sourcemap-codec@^1.4.14":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
+  integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
@@ -1869,6 +2076,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
+  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@mapbox/geojson-rewind@^0.5.2":
   version "0.5.2"
@@ -3638,6 +3853,11 @@
     "@types/react" "*"
     "@types/react-instantsearch-core" "*"
 
+"@types/react-transition-group@^4.4.0":
+  version "4.4.12"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.12.tgz#b5d76568485b02a307238270bfe96cb51ee2a044"
+  integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
+
 "@types/react@*":
   version "18.2.6"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.6.tgz#5cd53ee0d30ffc193b159d3516c8c8ad2f19d571"
@@ -4351,6 +4571,15 @@ babel-eslint@>=4.1.1:
     eslint-visitor-keys "^1.0.0"
     resolve "^1.12.0"
 
+babel-plugin-macros@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
+  integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    cosmiconfig "^7.0.0"
+    resolve "^1.19.0"
+
 babel-plugin-polyfill-corejs2@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz#5d1bd3836d0a19e1b84bbf2d9640ccb6f951c122"
@@ -4824,7 +5053,7 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
-client-only@0.0.1, client-only@^0.0.1:
+client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
@@ -4958,7 +5187,7 @@ constant-case@^3.0.4:
     tslib "^2.0.3"
     upper-case "^2.0.2"
 
-convert-source-map@^1.7.0:
+convert-source-map@^1.5.0, convert-source-map@^1.7.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
@@ -5330,6 +5559,14 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@^1.0.1:
   version "1.4.1"
@@ -6581,6 +6818,11 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
 find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -7193,7 +7435,7 @@ hey-listen@^1.0.8:
   resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
   integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -8486,6 +8728,11 @@ meilisearch@^0.30.0:
   dependencies:
     cross-fetch "^3.1.5"
 
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -9679,7 +9926,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -9819,11 +10066,6 @@ react-dom@18.3.1:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
-react-fast-compare@^3.0.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
-  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
-
 react-hook-form@^7.39.1:
   version "7.43.9"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.43.9.tgz#84b56ac2f38f8e946c6032ccb760e13a1037c66d"
@@ -9875,14 +10117,6 @@ react-markdown@^8.0.3:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
-react-popper@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
-  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
-  dependencies:
-    react-fast-compare "^3.0.1"
-    warning "^4.0.2"
-
 react-property@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
@@ -9913,6 +10147,21 @@ react-resize-detector@^7.1.2:
   integrity sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==
   dependencies:
     lodash "^4.17.21"
+
+react-select@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.10.0.tgz#9b5f4544cfecdfc744184b87651468ee0fb6e172"
+  integrity sha512-k96gw+i6N3ExgDwPIg0lUPmexl1ygPe6u5BdQFNBhkpbwroIgCNXdubtIzHfThYXYYTubwOBafoMnn7ruEP1xA==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.8.1"
+    "@floating-ui/dom" "^1.0.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^6.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+    use-isomorphic-layout-effect "^1.2.0"
 
 react-stately@^3.16.0:
   version "3.22.0"
@@ -9950,6 +10199,16 @@ react-style-singleton@^2.2.1:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
     tslib "^2.0.0"
+
+react-transition-group@^4.3.0:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react-transition-state@^1.1.5:
   version "1.1.5"
@@ -10040,6 +10299,11 @@ regenerator-runtime@^0.13.11:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regenerator-transform@^0.15.1:
   version "0.15.1"
@@ -10223,21 +10487,21 @@ resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.22
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@^1.19.0, resolve@^1.22.4:
+  version "1.22.10"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
+  integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
+  dependencies:
+    is-core-module "^2.16.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resolve@^1.22.3:
   version "1.22.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.3.tgz#4b4055349ffb962600972da1fdc33c46a4eb3283"
   integrity sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==
   dependencies:
     is-core-module "^2.12.0"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
-
-resolve@^1.22.4:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
-  integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
-  dependencies:
-    is-core-module "^2.16.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -10702,6 +10966,11 @@ source-map-js@^1.2.0:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+source-map@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
+
 source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -11019,6 +11288,11 @@ styled-jsx@5.1.1:
   integrity sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==
   dependencies:
     client-only "0.0.1"
+
+stylis@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
+  integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
 sucrase@^3.32.0:
   version "3.32.0"
@@ -11682,6 +11956,11 @@ use-isomorphic-layout-effect@^1.1.1:
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
   integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
+use-isomorphic-layout-effect@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz#afb292eb284c39219e8cb8d3d62d71999361a21d"
+  integrity sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==
+
 use-query-params@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-2.2.1.tgz#c558ab70706f319112fbccabf6867b9f904e947d"
@@ -11805,13 +12084,6 @@ vt-pbf@^3.1.3:
     "@mapbox/point-geometry" "0.1.0"
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
-
-warning@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  dependencies:
-    loose-envify "^1.0.0"
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Description

- Implement an accessible `AccordionItem` component, as in OLO, without external libraries
- Implement an accessible `Select` component using `react-select` as in OLO
- Remove `headlessui` from Marianum as we no longer want to use this library

### Testing

- Testing Accordion component: Confirm that the component behaves the same as on Marianum prod. See for example: https://marianum.sk/aktuality/casto-kladene-otazky

- Testing Select component: Confirm that the component behaves the same as on Marianum prod. See for example: https://marianum.sk/o-nas/dokumenty or https://marianum.sk/aktuality/novinky or https://marianum.sk/aktuality/kariera

### Supplementary notes

- _**This PR does not include support for multi-value selection or option grouping in multi-value select**_
<img width="600" alt="Screenshot 2025-03-03 at 15 48 36" src="https://github.com/user-attachments/assets/e6e77a34-9339-4f46-89df-b642a4da2bef" />

- Question: Which behaviour do we prefer when a select option is too long to fit the container?

| Text wrap - on prod | Truncation - this PR |
|----------|----------|
| <img width="391" alt="Screenshot 2025-03-03 at 12 51 51" src="https://github.com/user-attachments/assets/8ec83a0d-0161-49e2-a555-ba6701e0b6fb" /> | <img width="421" alt="Screenshot 2025-03-03 at 12 51 26" src="https://github.com/user-attachments/assets/63600657-07af-48a7-90c3-1d937c1be83e" /> |

### Screenshots

<img width="1728" alt="Screenshot 2025-03-03 at 12 57 22" src="https://github.com/user-attachments/assets/36f23449-91a7-4ee7-9818-2b2b873955b3" />

#### `Select` component

<img width="1728" alt="Screenshot 2025-03-03 at 13 00 42" src="https://github.com/user-attachments/assets/f05c19d0-6e62-43ce-92de-767ba0f36900" />

#### `AccordionGroup` component
