### PR TITLE
#372 Enhance accessibility and structure of Accordion components

### DIFF
--- a/next/components/molecules/Accordion/AccordionGroup.tsx
+++ b/next/components/molecules/Accordion/AccordionGroup.tsx
@@ -5,11 +5,7 @@ export type AccordionProps = {
 }
 
 const AccordionGroup = ({ children }: AccordionProps) => {
-  return (
-    <div role="group" className="flex w-full flex-col gap-5">
-      {children}
-    </div>
-  )
+  return <div className="flex w-full flex-col gap-5">{children}</div>
 }
 
 export default AccordionGroup

--- a/next/components/molecules/Accordion/AccordionGroup.tsx
+++ b/next/components/molecules/Accordion/AccordionGroup.tsx
@@ -5,7 +5,11 @@ export type AccordionProps = {
 }
 
 const AccordionGroup = ({ children }: AccordionProps) => {
-  return <div className="flex w-full flex-col gap-5">{children}</div>
+  return (
+    <div role="group" className="flex w-full flex-col gap-5">
+      {children}
+    </div>
+  )
 }
 
 export default AccordionGroup

--- a/next/components/molecules/Accordion/AccordionItem.tsx
+++ b/next/components/molecules/Accordion/AccordionItem.tsx
@@ -1,4 +1,3 @@
-import { Disclosure } from '@headlessui/react'
 import cx from 'classnames'
 import { ReactNode, useContext } from 'react'
 
@@ -14,6 +13,10 @@ export type AccordionItemProps = {
   noBoxStyles?: boolean
 }
 
+/**
+ * Based on OLO: https://github.com/bratislava/olo.sk/blob/master/next/src/components/lib/Accordion/Accordion.tsx
+ */
+
 const AccordionItem = ({
   title,
   additionalInfo,
@@ -24,49 +27,48 @@ const AccordionItem = ({
   const { border: contextBorder } = useContext(sectionContext)
 
   return (
-    <Disclosure>
-      {({ open }) => {
-        return (
+    <AnimateHeight
+      isVisible
+      className="focus-within:[z-1] relative ring-offset-2 transition focus-within:[&:has(:focus-visible)]:ring"
+    >
+      <div>
+        <details
+          className={cx('group flex w-full flex-col bg-white', {
+            'border border-border': (border ?? contextBorder) && !noBoxStyles,
+          })}
+        >
+          <summary
+            className={cx(
+              'flex cursor-pointer justify-between gap-4 text-left text-h5 focus:outline-none',
+              { 'p-4 sm:p-5 md:p-6': !noBoxStyles },
+            )}
+          >
+            <h3 className="py-[3px] text-h5">{title}</h3>
+            {additionalInfo && <div className="pr-6">{additionalInfo}</div>}
+            <div
+              className={cx(
+                'flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white',
+                { 'border border-border': !noBoxStyles },
+              )}
+            >
+              <ChevronDownIcon
+                aria-hidden
+                className="text-primary transition-transform group-open:rotate-180"
+              />
+            </div>
+          </summary>
+
           <div
-            className={cx('flex w-full flex-col bg-white', {
-              'border border-border': (border ?? contextBorder) && !noBoxStyles,
+            className={cx('w-full', {
+              'px-4 pb-4 sm:px-5 sm:pb-5 md:px-6 md:pb-6': !noBoxStyles,
+              'pt-4 sm:pt-5 md:pt-6': noBoxStyles,
             })}
           >
-            <Disclosure.Button
-              className={cx('flex justify-between gap-4 text-left text-h5', {
-                'p-4 sm:p-5 md:p-6': !noBoxStyles,
-              })}
-            >
-              <h3 className="py-[3px] text-h5">{title}</h3>
-              {additionalInfo && <div className="pr-6">{additionalInfo}</div>}
-              <div
-                className={cx(
-                  'flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white',
-                  { 'border border-border': !noBoxStyles },
-                )}
-              >
-                <ChevronDownIcon
-                  className={cx('transform text-primary transition-transform', {
-                    'rotate-180': open,
-                  })}
-                />
-              </div>
-            </Disclosure.Button>
-            <AnimateHeight isVisible={open}>
-              <Disclosure.Panel
-                static
-                className={cx('w-full', {
-                  'px-4 pb-4 sm:px-5 sm:pb-5 md:px-6 md:pb-6': !noBoxStyles,
-                  'pt-4 sm:pt-5 md:pt-6': noBoxStyles,
-                })}
-              >
-                {children}
-              </Disclosure.Panel>
-            </AnimateHeight>
+            {children}
           </div>
-        )
-      }}
-    </Disclosure>
+        </details>
+      </div>
+    </AnimateHeight>
   )
 }
 

--- a/next/components/molecules/Accordion/AccordionItem.tsx
+++ b/next/components/molecules/Accordion/AccordionItem.tsx
@@ -47,7 +47,7 @@ const AccordionItem = ({
             {additionalInfo && <div className="pr-6">{additionalInfo}</div>}
             <div
               className={cx(
-                'flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white',
+                'flex size-8 shrink-0 items-center justify-center rounded-full bg-white',
                 { 'border border-border': !noBoxStyles },
               )}
             >

--- a/next/styles/globals.css
+++ b/next/styles/globals.css
@@ -8,36 +8,40 @@
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 400;
-    src: local(''),
-    url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff2') format('woff2'),
-    url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff') format('woff');
+    src:
+      local(''),
+      url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff2') format('woff2'),
+      url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff') format('woff');
   }
   /* noto-sans-600 - latin-ext_latin */
   @font-face {
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 600;
-    src: local(''),
-    url('/fonts/noto-sans-v27-latin-ext_latin-600.woff2') format('woff2'),
-    url('/fonts/noto-sans-v27-latin-ext_latin-600.woff') format('woff');
+    src:
+      local(''),
+      url('/fonts/noto-sans-v27-latin-ext_latin-600.woff2') format('woff2'),
+      url('/fonts/noto-sans-v27-latin-ext_latin-600.woff') format('woff');
   }
   /* noto-sans-700 - latin-ext_latin */
   @font-face {
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 700;
-    src: local(''),
-    url('/fonts/noto-sans-v27-latin-ext_latin-700.woff2') format('woff2'),
-    url('/fonts/noto-sans-v27-latin-ext_latin-700.woff') format('woff');
+    src:
+      local(''),
+      url('/fonts/noto-sans-v27-latin-ext_latin-700.woff2') format('woff2'),
+      url('/fonts/noto-sans-v27-latin-ext_latin-700.woff') format('woff');
   }
   /* ABCArizonaFlare-Bold */
   @font-face {
     font-family: 'ABC Arizona Flare';
     font-style: normal;
     font-weight: 700;
-    src: local(''),
-    url('/fonts/ABCArizonaFlare-Bold.woff2') format('woff2'),
-    url('/fonts/ABCArizonaFlare-Bold.woff') format('woff');
+    src:
+      local(''),
+      url('/fonts/ABCArizonaFlare-Bold.woff2') format('woff2'),
+      url('/fonts/ABCArizonaFlare-Bold.woff') format('woff');
   }
 
   @supports (-webkit-text-stroke: 4px #446650) {

--- a/next/styles/globals.css
+++ b/next/styles/globals.css
@@ -8,40 +8,36 @@
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 400;
-    src:
-      local(''),
-      url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff2') format('woff2'),
-      url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff') format('woff');
+    src: local(''),
+    url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff2') format('woff2'),
+    url('/fonts/noto-sans-v27-latin-ext_latin-regular.woff') format('woff');
   }
   /* noto-sans-600 - latin-ext_latin */
   @font-face {
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 600;
-    src:
-      local(''),
-      url('/fonts/noto-sans-v27-latin-ext_latin-600.woff2') format('woff2'),
-      url('/fonts/noto-sans-v27-latin-ext_latin-600.woff') format('woff');
+    src: local(''),
+    url('/fonts/noto-sans-v27-latin-ext_latin-600.woff2') format('woff2'),
+    url('/fonts/noto-sans-v27-latin-ext_latin-600.woff') format('woff');
   }
   /* noto-sans-700 - latin-ext_latin */
   @font-face {
     font-family: 'Noto Sans';
     font-style: normal;
     font-weight: 700;
-    src:
-      local(''),
-      url('/fonts/noto-sans-v27-latin-ext_latin-700.woff2') format('woff2'),
-      url('/fonts/noto-sans-v27-latin-ext_latin-700.woff') format('woff');
+    src: local(''),
+    url('/fonts/noto-sans-v27-latin-ext_latin-700.woff2') format('woff2'),
+    url('/fonts/noto-sans-v27-latin-ext_latin-700.woff') format('woff');
   }
   /* ABCArizonaFlare-Bold */
   @font-face {
     font-family: 'ABC Arizona Flare';
     font-style: normal;
     font-weight: 700;
-    src:
-      local(''),
-      url('/fonts/ABCArizonaFlare-Bold.woff2') format('woff2'),
-      url('/fonts/ABCArizonaFlare-Bold.woff') format('woff');
+    src: local(''),
+    url('/fonts/ABCArizonaFlare-Bold.woff2') format('woff2'),
+    url('/fonts/ABCArizonaFlare-Bold.woff') format('woff');
   }
 
   @supports (-webkit-text-stroke: 4px #446650) {
@@ -65,9 +61,9 @@
   */
   html,
   body,
-  /* next main div */
+    /* next main div */
   #__next,
-  /* <OverlayProvider /> from react-aria */
+    /* <OverlayProvider /> from react-aria */
   #__next > [data-overlay-container='true'] {
     @apply h-full;
   }
@@ -223,4 +219,13 @@
 .full-width-canvas-page canvas {
   width: 100% !important;
   height: auto !important;
+}
+
+/* Remove native Safari arrows in accordions  */
+details > summary {
+  list-style: none;
+}
+
+details > summary::-webkit-details-marker {
+  display: none;
 }


### PR DESCRIPTION
### Description

- Implement an accessible `AccordionItem` component, as in OLO, without external libraries

### Testing

- Testing Accordion component: Confirm that the component behaves the same as on Marianum prod. See for example: https://marianum.sk/aktuality/casto-kladene-otazky

### Screenshots

<img width="1728" alt="Screenshot 2025-03-03 at 13 00 42" src="https://github.com/user-attachments/assets/f05c19d0-6e62-43ce-92de-767ba0f36900" />