### PR TITLE
#522 BugFix ServiceCards in CardSection

### DIFF
--- a/next/components/molecules/Cards/ServiceCard.tsx
+++ b/next/components/molecules/Cards/ServiceCard.tsx
@@ -28,7 +28,7 @@ const ServiceCard = ({ image, title, linkHref, ...rest }: ServiceCardProps) => {
       <div className="relative aspect-square w-full bg-gray">
         {image ? <MImage image={image} fill className="object-contain" /> : <ImagePlaceholder />}
       </div>
-      <CardContent className="justify-between">
+      <CardContent className="h-full justify-between">
         <div>
           <h3 id={titleId} className="line-clamp-3 text-h5 group-hover:underline">
             {title}

--- a/next/components/sections/CardSection.tsx
+++ b/next/components/sections/CardSection.tsx
@@ -1,13 +1,9 @@
-import cx from 'classnames'
-import { useMemo } from 'react'
-
 import { CategoryCard } from '@/components/molecules/Cards/CategoryFaqThemeCard'
 import ServiceCard from '@/components/molecules/Cards/ServiceCard'
 import { useGetFullPath } from '@/components/molecules/Navigation/NavigationProvider/useGetFullPath'
 import Section, { SectionProps } from '@/components/molecules/Section'
 import { Enum_Componentsectionsmanuallisting_Style, ManualListingFragment } from '@/graphql'
 import { isDefined } from '@/utils/isDefined'
-import { useTailwindBreakpoint } from '@/utils/useTailwindBreakpoint'
 
 type CardSectionProps = Pick<SectionProps, 'background'> & {
   section: ManualListingFragment
@@ -22,9 +18,6 @@ const CardSection = ({ section, ...rest }: CardSectionProps) => {
     ?.filter(isDefined)
     .map((page) => page.page?.data)
     .filter((page) => page?.attributes)
-
-  const { isMD } = useTailwindBreakpoint()
-  const isMobile = useMemo(() => !isMD, [isMD])
 
   return (
     <Section
@@ -56,9 +49,7 @@ const CardSection = ({ section, ...rest }: CardSectionProps) => {
             <ServiceCard
               // eslint-disable-next-line react/no-array-index-key, @typescript-eslint/restrict-template-expressions
               key={`${id}-${index}`}
-              className={cx({
-                'w-[calc(100vw-6rem)] shrink-0 sm:w-[calc(100vw-16rem)]': isMobile,
-              })}
+              className="w-4/5 shrink-0 sm:w-2/5 md:w-full"
               title={cardTitle ?? ''}
               linkHref={fullPath}
               image={coverMedia?.data?.attributes}


### PR DESCRIPTION
### Description
CSS changes in cards were needed in order to display them correctly.

### Testing
On homepage, check that the service cards are displayed correctly - on all display sizes. On small displays, cards should overflow with a bit of the next card peeking from the right to indicate swiping.