### PR TITLE
#364 Add focus rings to input-like components, gallery, and slider

### DIFF
--- a/next/components/atoms/TextField.tsx
+++ b/next/components/atoms/TextField.tsx
@@ -63,7 +63,7 @@ const TextField = forwardRef<HTMLTextAreaElement & HTMLInputElement, TextFieldPr
             disabled={disabled}
             required={required}
             className={cx(
-              'min-h-10 w-full resize-y bg-transparent px-4 py-[6px] outline-none',
+              'base-focus-ring min-h-10 w-full resize-y bg-transparent px-4 py-[6px]',
               inputClassName,
               {
                 'text-foreground-disabled': disabled,
@@ -114,7 +114,7 @@ const TextField = forwardRef<HTMLTextAreaElement & HTMLInputElement, TextFieldPr
           id={generatedOrProvidedId}
           disabled={disabled}
           required={required}
-          className={cx('w-full bg-transparent outline-none', inputClassName, {
+          className={cx('base-focus-ring w-full bg-transparent', inputClassName, {
             'text-foreground-disabled': disabled,
             'pl-4': !leftSlot,
             'pr-4': !rightSlot,

--- a/next/components/molecules/Accordion/AccordionItem.tsx
+++ b/next/components/molecules/Accordion/AccordionItem.tsx
@@ -29,7 +29,7 @@ const AccordionItem = ({
   return (
     <AnimateHeight
       isVisible
-      className="focus-within:[z-1] relative ring-offset-2 transition focus-within:[&:has(:focus-visible)]:ring"
+      className="relative ring-offset-2 transition focus-within:z-[1] focus-within:[&:has(:focus-visible)]:ring"
     >
       <div>
         <details

--- a/next/components/molecules/ImageGallery.tsx
+++ b/next/components/molecules/ImageGallery.tsx
@@ -81,7 +81,7 @@ const ImageGallery = ({ images = [], variant = 'below' }: ImageGalleryProps) => 
           tabIndex={0}
           aria-label={t('ImageGallery.aria.openImageGallery')}
           onKeyUp={onEnterOrSpaceKeyDown(() => openAtImageIndex(0))}
-          className={cx('cursor-default outline-offset-2 outline-primary focus:outline-4', {
+          className={cx('base-focus-ring', {
             'flex flex-col': variant === 'below',
             'grid grid-cols-[minmax(0,1fr)_auto]': variant === 'aside',
           })}
@@ -90,7 +90,7 @@ const ImageGallery = ({ images = [], variant = 'below' }: ImageGalleryProps) => 
           {firstImage && (
             <div
               onClick={() => openAtImageIndex(0)}
-              className={cx('relative w-full cursor-pointer', {
+              className={cx('relative w-full', {
                 // large 'below' layout
                 'h-[500px]': thumbnailCount > 6 && variant === 'below',
                 // small & middle 'below' layout
@@ -123,7 +123,7 @@ const ImageGallery = ({ images = [], variant = 'below' }: ImageGalleryProps) => 
                   <div
                     onClick={() => openAtImageIndex(index + 1)}
                     key={image.id}
-                    className="relative w-full cursor-pointer pt-[100%]"
+                    className="relative w-full pt-[100%]"
                   >
                     <MImage
                       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -138,7 +138,7 @@ const ImageGallery = ({ images = [], variant = 'below' }: ImageGalleryProps) => 
               {moreImagesCount > 0 && (
                 <div
                   onClick={() => openAtImageIndex(0)}
-                  className="relative w-full cursor-pointer border border-border pt-[100%]"
+                  className="relative w-full border border-border pt-[100%]"
                 >
                   <div className="absolute top-0 flex size-full items-center justify-center bg-white p-2 text-center font-semibold text-primary">
                     {t('ImageGallery.morePhotos', { count: moreImagesCount })}
@@ -163,7 +163,7 @@ const ImageGallery = ({ images = [], variant = 'below' }: ImageGalleryProps) => 
                   <div
                     onClick={() => openAtImageIndex(index + 1)}
                     key={image.id}
-                    className="relative w-[168px] cursor-pointer pt-[168px]"
+                    className="relative w-[168px] pt-[168px]"
                   >
                     <MImage
                       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -176,10 +176,7 @@ const ImageGallery = ({ images = [], variant = 'below' }: ImageGalleryProps) => 
 
               {/* more images button */}
               {moreImagesCount > 0 && (
-                <div
-                  onClick={() => openAtImageIndex(0)}
-                  className="relative w-[168px] cursor-pointer pt-[166px]"
-                >
+                <div onClick={() => openAtImageIndex(0)} className="relative w-[168px] pt-[166px]">
                   <div className="absolute top-0 flex size-full items-center justify-center bg-white p-8 text-center font-semibold text-primary">
                     {t('ImageGallery.showAllPhotos')}
                   </div>

--- a/next/components/molecules/Slider.tsx
+++ b/next/components/molecules/Slider.tsx
@@ -136,13 +136,11 @@ const Slider = forwardRef<HTMLDivElement, SliderProps>(
     return (
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <div
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-        tabIndex={0}
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
         ref={forwardedRef}
         onKeyUp={keyUpHandler}
-        role="application"
+        role="region"
         aria-label={description ?? t('Slider.aria.description')}
         className="relative z-0 flex size-full items-center justify-center overflow-hidden"
       >

--- a/next/components/molecules/Slider.tsx
+++ b/next/components/molecules/Slider.tsx
@@ -140,6 +140,9 @@ const Slider = forwardRef<HTMLDivElement, SliderProps>(
         onBlur={() => setFocused(false)}
         ref={forwardedRef}
         onKeyUp={keyUpHandler}
+        // We use role="region" instead of role="application" as it breaks keyboard navigation
+        // Region refers to "an important content that users may want to navigate to"
+        // TODO: OLO uses role="tabpanel" but this implementation would require some refactoring
         role="region"
         aria-label={description ?? t('Slider.aria.description')}
         className="relative z-0 flex size-full items-center justify-center overflow-hidden"

--- a/next/components/sections/HomepageSlider.tsx
+++ b/next/components/sections/HomepageSlider.tsx
@@ -28,6 +28,8 @@ const HomepageSlider = ({ slides }: HomepageSliderProps) => {
     <div className="relative h-[412px] bg-primary-dark text-white lg:h-[436px]">
       <Slider
         autoSwipeDuration={5000}
+        description={t('HomepageSlider.aria.heading')}
+        // To prevent the screen reader from reading the aria-label twice (Slider component already has a default aria-label)
         allowKeyboardNavigation
         pages={slides.map(({ title, description, button, image }, index) => {
           const ctaSlug = getFullPath(button?.page?.data)
@@ -40,7 +42,6 @@ const HomepageSlider = ({ slides }: HomepageSliderProps) => {
               // eslint-disable-next-line react/no-array-index-key
               key={index}
             >
-              <h2 className="sr-only">{t('HomepageSlider.aria.heading')}</h2>
               <div className="container absolute flex h-full flex-row items-center justify-center lg:justify-start">
                 {/* 60% of container width is not the same as 60% of window (image offset from left), but this setting works fine */}
                 <div className="flex size-full flex-col items-center pb-16 lg:w-3/5 lg:items-start lg:justify-end lg:pb-[104px]">

--- a/next/components/sections/HomepageSlider.tsx
+++ b/next/components/sections/HomepageSlider.tsx
@@ -28,8 +28,8 @@ const HomepageSlider = ({ slides }: HomepageSliderProps) => {
     <div className="relative h-[412px] bg-primary-dark text-white lg:h-[436px]">
       <Slider
         autoSwipeDuration={5000}
-        description={t('HomepageSlider.aria.heading')}
         // To prevent the screen reader from reading the aria-label twice (Slider component already has a default aria-label)
+        description={t('HomepageSlider.aria.heading')}
         allowKeyboardNavigation
         pages={slides.map(({ title, description, button, image }, index) => {
           const ctaSlug = getFullPath(button?.page?.data)

--- a/next/pages/search.tsx
+++ b/next/pages/search.tsx
@@ -91,7 +91,7 @@ const SearchSection = () => {
           <Search value={searchQuery ?? ''} onSearchQueryChange={setSearchQuery} />
         </div>
         <div className="flex flex-col-reverse justify-between gap-3 md:flex-row md:items-center">
-          <div className="flex w-full items-center gap-3 overflow-auto pb-3 sm:pb-0">
+          <div className="-m-2 flex w-full items-center gap-3 overflow-auto p-2 pb-3 sm:pb-2 md:overflow-visible">
             <TagToggle isSelected={isNothingSelected} onChange={deselectAll}>
               {t('SearchPage.allResults')}
             </TagToggle>

--- a/next/pages/styleguide.tsx
+++ b/next/pages/styleguide.tsx
@@ -470,7 +470,7 @@ const Showcase = () => {
               <TextField
                 id="deafault-left-icon"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <SearchIcon />
                   </button>
                 }
@@ -479,7 +479,7 @@ const Showcase = () => {
               <TextField
                 id="deafault-right-icon"
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <CloseCircleIcon />
                   </button>
                 }
@@ -488,12 +488,12 @@ const Showcase = () => {
               <TextField
                 id="deafault-both-icons"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <SearchIcon />
                   </button>
                 }
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <CloseCircleIcon />
                   </button>
                 }
@@ -507,7 +507,7 @@ const Showcase = () => {
                 id="with-text-left-icon"
                 defaultValue="Input"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <SearchIcon />
                   </button>
                 }
@@ -517,7 +517,7 @@ const Showcase = () => {
                 id="with-text-right-icon"
                 defaultValue="Input"
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <CloseCircleIcon />
                   </button>
                 }
@@ -527,12 +527,12 @@ const Showcase = () => {
                 id="with-text-both-icons"
                 defaultValue="Input"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <SearchIcon />
                   </button>
                 }
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <CloseCircleIcon />
                   </button>
                 }
@@ -547,7 +547,7 @@ const Showcase = () => {
                 error
                 defaultValue="Input"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <SearchIcon />
                   </button>
                 }
@@ -558,7 +558,7 @@ const Showcase = () => {
                 error
                 defaultValue="Input"
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <CloseCircleIcon />
                   </button>
                 }
@@ -569,12 +569,12 @@ const Showcase = () => {
                 error
                 defaultValue="Input"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <SearchIcon />
                   </button>
                 }
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <CloseCircleIcon />
                   </button>
                 }
@@ -589,7 +589,7 @@ const Showcase = () => {
                 disabled
                 defaultValue="Input"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2" disabled>
                     <SearchIcon />
                   </button>
                 }
@@ -600,7 +600,7 @@ const Showcase = () => {
                 disabled
                 defaultValue="Input"
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2" disabled>
                     <CloseCircleIcon />
                   </button>
                 }
@@ -611,12 +611,12 @@ const Showcase = () => {
                 disabled
                 defaultValue="Input"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2" disabled>
                     <SearchIcon />
                   </button>
                 }
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2" disabled>
                     <CloseCircleIcon />
                   </button>
                 }
@@ -631,7 +631,7 @@ const Showcase = () => {
                 id="with-label-left-icon"
                 defaultValue="Input"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <SearchIcon />
                   </button>
                 }
@@ -642,7 +642,7 @@ const Showcase = () => {
                 id="with-label-right-icon"
                 defaultValue="Input"
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <CloseCircleIcon />
                   </button>
                 }
@@ -653,12 +653,12 @@ const Showcase = () => {
                 id="with-label-both-icons"
                 defaultValue="Input"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <SearchIcon />
                   </button>
                 }
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <CloseCircleIcon />
                   </button>
                 }
@@ -680,7 +680,7 @@ const Showcase = () => {
                 id="with-label-required-left-icon"
                 defaultValue="Input"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <SearchIcon />
                   </button>
                 }
@@ -692,7 +692,7 @@ const Showcase = () => {
                 id="with-label-required-right-icon"
                 defaultValue="Input"
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <CloseCircleIcon />
                   </button>
                 }
@@ -704,12 +704,12 @@ const Showcase = () => {
                 id="with-label-required-both-icons"
                 defaultValue="Input"
                 leftSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <SearchIcon />
                   </button>
                 }
                 rightSlot={
-                  <button type="button" className="p-2">
+                  <button type="button" className="base-focus-ring p-2">
                     <CloseCircleIcon />
                   </button>
                 }


### PR DESCRIPTION
### Description

- Add focus rings to input-like components, gallery, and slider

### Testing

- Try tabbing over various button and link elements on the page using the keyboard
- You should see a focus ring

#### Specific examples

- ImageGallery: http://localhost:3000/sluzby/kvetinarstvo/katalog-kvetov
- MapSection: http://localhost:3000/o-nas/cintoriny-v-sprave
- HomepageSlider, Slider: http://localhost:3000
- Search, TextField, FilteringSearchInput: http://localhost:3000/styleguide

- search - fixing cropped focus rings on tag/chip elements: http://localhost:3000/vyhladavanie

### Supplementary notes

#### 1.

Custom focus ring styles for `Checkbox` cannot be applied because the focus focus ring is managed by `useFocusRing` from react-aria, which applies accessibility-focused styles automatically.

> Do we want to create a new task for this?

#### 2.

`HomepageSlider` was breaking keyboard navigation due to `role="application`". When `role="application` is applied, screen readers stop using their normal navigation keys (like arrow keys to read content). Also, when tabbing over the slides, when a new slide arrives, the focus is applied to the menu. This happens with every new slide. We should probably refactor this component in the future.

> Do we want to create a new task for this?

#### 3.

Focus ring logic of `TextField`. Our input elements currently have split focus rings. This affects usability and does not align with expected focus indicator behaviour.

<img width="1165" alt="Screenshot 2025-03-12 at 15 15 32" src="https://github.com/user-attachments/assets/31753c54-25a2-425f-9707-ec01e501af2c" />

<img width="1178" alt="Screenshot 2025-03-12 at 15 15 41" src="https://github.com/user-attachments/assets/8a75e7c4-4ba9-49e9-af37-17b0259e647e" />


> Do we want to create a new task for this?
