### PR TITLE
#364 Add focus rings to menu and breadcrumbs

### DIFF
--- a/next/components/atoms/Breadcrumbs.tsx
+++ b/next/components/atoms/Breadcrumbs.tsx
@@ -36,7 +36,7 @@ const BreadcrumbChild = ({
   ariaLabel,
 }: BreadcrumbChildProps) => {
   return (
-    <div className={cx('flex gap-1 overflow-hidden', { 'shrink-0': dontShrink })}>
+    <div className={cx('-m-2 flex gap-1 overflow-hidden p-2', { 'shrink-0': dontShrink })}>
       {!noChevron && (
         <div className="shrink-0 -rotate-90 pt-[2px]">
           <ChevronDownIcon />

--- a/next/components/molecules/Menu/Menu.tsx
+++ b/next/components/molecules/Menu/Menu.tsx
@@ -39,7 +39,7 @@ const Menu = ({ items, title, path }: MenuProps) => {
         noStyles
         href={path ?? ''}
         className={cx(
-          'flex h-full w-full items-center justify-center font-semibold outline-none transition-all focus:bg-primary/10',
+          'flex h-full w-full items-center justify-center font-semibold ring-inset ring-offset-0 transition-all focus:bg-primary/10',
           { 'bg-primary/10': isOpen },
         )}
         onPointerEnter={() => toggleMenu(true)}

--- a/next/components/molecules/Navigation/NavigationMenuMobile.tsx
+++ b/next/components/molecules/Navigation/NavigationMenuMobile.tsx
@@ -40,7 +40,7 @@ const RenderItems = ({
             key={id}
             onMouseUp={() => onOpenItem && onOpenItem(id)}
             type="button"
-            className="flex w-full justify-between px-4 py-3 focus:bg-primary/10"
+            className="base-focus-ring flex w-full justify-between px-4 py-3 focus:bg-primary/10"
           >
             <span className="font-semibold">{title}</span>
             <div className="-rotate-90">
@@ -54,7 +54,7 @@ const RenderItems = ({
             key={id}
             noStyles={LinkComponent === 'div' ? undefined : true}
             href={path ?? ''}
-            className="flex w-full justify-between px-4 py-3 focus:bg-primary/10"
+            className="base-focus-ring flex w-full justify-between px-4 py-3 focus:bg-primary/10"
           >
             <span className="font-semibold">{title}</span>
           </LinkComponent>


### PR DESCRIPTION
### Description

- Add focus rings to menu (desktop and mobile) and breadcrumbs

### Testing

Explain how the changes have been tested. Mention the methods, tools, and browsers (e.g., Chrome, Firefox, Safari) used.

### Supplementary notes

Include any TODOs, notable considerations, or known gaps in this update. Provide supporting context and links to
documentation to simplify the review process.

### Screenshots

Attach images or screencasts demonstrating the changes, if applicable. Visuals can help reviewers understand the
updates.
