### PR TITLE
#493 quickfix gallery counter

### DIFF
--- a/next/components/molecules/ImageGallery.tsx
+++ b/next/components/molecules/ImageGallery.tsx
@@ -53,8 +53,9 @@ const ImageGallery = ({ images = [], variant = 'below' }: ImageGalleryProps) => 
   }, [containerWidth, variant])
 
   // number of not displayed images
+  // TODO: for gallery in cemeteries this count is not correct
   const moreImagesCount = useMemo(() => {
-    return Math.max(imageCount - thumbnailCount, 0)
+    return Math.max(imageCount - thumbnailCount, 0) 
   }, [imageCount, thumbnailCount])
 
   const smallImages = useMemo(() => {
@@ -141,7 +142,8 @@ const ImageGallery = ({ images = [], variant = 'below' }: ImageGalleryProps) => 
                   className="relative w-full cursor-pointer border border-border pt-[100%]"
                 >
                   <div className="absolute top-0 flex size-full items-center justify-center bg-white p-2 text-center font-semibold text-primary">
-                    {t('ImageGallery.morePhotos', { count: moreImagesCount })}
+                    {/* TODO: before there was also count shown, but it was wrongly calculated t('ImageGallery.morePhotos', { count: moreImagesCount }) */}
+                    {t('ImageGallery.showAllPhotos')}
                   </div>
                 </div>
               )}

--- a/next/components/molecules/ImageGallery.tsx
+++ b/next/components/molecules/ImageGallery.tsx
@@ -55,7 +55,7 @@ const ImageGallery = ({ images = [], variant = 'below' }: ImageGalleryProps) => 
   // number of not displayed images
   // TODO: for gallery in cemeteries this count is not correct
   const moreImagesCount = useMemo(() => {
-    return Math.max(imageCount - thumbnailCount, 0) 
+    return Math.max(imageCount - thumbnailCount, 0)
   }, [imageCount, thumbnailCount])
 
   const smallImages = useMemo(() => {


### PR DESCRIPTION
### Description

Calculation of gallery "more" images in cemeteries was showing wrong value. 
Quickfix is to show "Zobrazit vsetky fotky" as it is on other occurencies of ImageGallery.
Issue for the fix was created

### Testing
In strapi cemetery page add gallery with more than 4 images - you should see button for show more 


### Screenshots
![gallery-fix](https://github.com/user-attachments/assets/84657036-1cbf-429d-b914-2b8a8006b024)
