### PR TITLE
#590 Align Tabs selection state with sessionStorage

### DIFF
--- a/next/components/atoms/Tabs/Tabs.tsx
+++ b/next/components/atoms/Tabs/Tabs.tsx
@@ -11,17 +11,22 @@ import TabPanel from './TabPanel'
 
 const Tabs = <T extends object>(props: TabListProps<T>) => {
   const ref = useRef<HTMLDivElement | null>(null)
-  const state = useTabListState<T>(props)
   const { isNull: isBreakpointNull } = useTailwindBreakpoint()
-  const { tabListProps } = useTabList(
-    { ...props, orientation: isBreakpointNull ? 'vertical' : 'horizontal' },
-    state,
-    ref,
-  )
 
   const [sessionTabKey, setSessionTabKey] = useSessionStorage<string>(
     'marianum-decease-place-tabs',
     '',
+  )
+
+  const state = useTabListState<T>({
+    ...props,
+    defaultSelectedKey: sessionTabKey,
+  })
+
+  const { tabListProps } = useTabList(
+    { ...props, orientation: isBreakpointNull ? 'vertical' : 'horizontal' },
+    state,
+    ref,
   )
 
   useEffect(() => {


### PR DESCRIPTION
## Desription

- probable cause: race condition between session storage and useEffect
 
## Testing

- Both the homepage and also the page http://localhost:3000/vybavenie-pohrebu/navod-ako-postupovat should keep the selected tap synchronized
- try selecting the second tab "Úmrtie v zariadení" on the homepage and (in the same browser tab) visit the page http://localhost:3000/vybavenie-pohrebu/navod-ako-postupovat should keep the selected tap synchronized and check that the second tab is also selected there
- you may try other combinations

![image](https://github.com/user-attachments/assets/57dc327c-0a5c-4f8d-83fe-5c052cd272c1)