### PR TITLE
#454 Allow other cemeteries in uploading the list of funerals  

### DIFF
--- a/next/components/sections/CeremoniesArchiveSection.tsx
+++ b/next/components/sections/CeremoniesArchiveSection.tsx
@@ -21,7 +21,7 @@ import {
   getCeremoniesArchiveSectionQueryKey,
 } from '@/services/fetchers/ceremonies/ceremoniesArchiveSectionFetcher'
 import { CeremonyMeili } from '@/services/meili/meiliTypes'
-import { getCemeteryInfoInCeremoniesDebtorsMeili } from '@/utils/getCemeteryInfoInCeremoniesDebtors'
+import { getCemeteryInfoFromCeremonyMeili } from '@/utils/getCemeteryInfoInCeremoniesDebtors'
 import { useHorizontalScrollFade } from '@/utils/useHorizontalScrollFade'
 import { useScrollToViewIfDataChange } from '@/utils/useScrollToViewIfDataChange'
 
@@ -52,13 +52,15 @@ const Table = ({
     }
 
     return ceremoniesData.map((ceremony) => {
-      const dateTime = new Date(ceremony.dateTime)
-      const { title, slug } = getCemeteryInfoInCeremoniesDebtorsMeili(
-        ceremony.cemetery,
-        i18n.language,
+      const cemeteryInfo = getCemeteryInfoFromCeremonyMeili(ceremony, i18n.language)
+
+      const cemetery = cemeteryInfo?.slug ? (
+        <CemeteryLink slug={cemeteryInfo.slug} title={cemeteryInfo.title ?? ''} />
+      ) : (
+        cemeteryInfo?.title
       )
 
-      const cemetery = slug ? <CemeteryLink slug={slug} title={title} /> : title
+      const dateTime = new Date(ceremony.dateTime)
 
       return {
         ...ceremony,
@@ -96,6 +98,7 @@ const Table = ({
                     <FormatDate value={ceremony.dateTime} format="ceremoniesArchive" />
                   )}
                 </td>
+                {/* <td>{JSON.stringify(ceremony)}</td> */}
                 <td>{ceremony.consentForPrivateFields ? ceremony.name : <PrivateField />}</td>
                 <td>{ceremony.consentForPrivateFields ? ceremony.birthYear : <PrivateField />}</td>
                 <td>{ceremony.cemetery}</td>

--- a/next/components/sections/CeremoniesSection.tsx
+++ b/next/components/sections/CeremoniesSection.tsx
@@ -23,7 +23,7 @@ import {
   getCeremoniesSectionQueryKey,
 } from '@/services/fetchers/ceremonies/ceremoniesSectionFetcher'
 import { bratislavaTimezone } from '@/utils/consts'
-import { getCemeteryInfoInCeremoniesDebtors } from '@/utils/getCemeteryInfoInCeremoniesDebtors'
+import { getCemeteryInfoFromCeremony } from '@/utils/getCemeteryInfoInCeremoniesDebtors'
 import { useHorizontalScrollFade } from '@/utils/useHorizontalScrollFade'
 import { useScrollToViewIfDataChange } from '@/utils/useScrollToViewIfDataChange'
 
@@ -104,12 +104,10 @@ const Table = ({ data, filters }: { data: CeremoniesQuery; filters: CeremoniesSe
     }
 
     const mappedCeremonies = ceremoniesData.map((ceremony) => {
-      const cemeteryInfo = ceremony?.attributes?.cemetery?.data
-        ? getCemeteryInfoInCeremoniesDebtors(ceremony.attributes.cemetery.data, i18n.language)
-        : null
+      const cemeteryInfo = getCemeteryInfoFromCeremony(ceremony, i18n.language)
 
       const cemetery = cemeteryInfo?.slug ? (
-        <CemeteryLink slug={cemeteryInfo?.slug} title={cemeteryInfo?.title ?? ''} />
+        <CemeteryLink slug={cemeteryInfo.slug} title={cemeteryInfo.title ?? ''} />
       ) : (
         cemeteryInfo?.title
       )

--- a/next/components/sections/UpcomingCeremoniesSection.tsx
+++ b/next/components/sections/UpcomingCeremoniesSection.tsx
@@ -15,7 +15,7 @@ import {
   upcomingCeremoniesFetcher,
 } from '@/services/fetchers/ceremonies/upcomingCeremoniesFetcher'
 import { bratislavaTimezone } from '@/utils/consts'
-import { getCemeteryInfoInCeremoniesDebtors } from '@/utils/getCemeteryInfoInCeremoniesDebtors'
+import { getCemeteryInfoFromCeremony } from '@/utils/getCemeteryInfoInCeremoniesDebtors'
 
 const Table = () => {
   const { t, i18n } = useTranslation()
@@ -52,12 +52,10 @@ const Table = () => {
     return {
       day: firstCeremonyDayDateTimeZoned.toDate(),
       ceremonies: filteredCeremonies.map((ceremony) => {
-        const cemeteryInfo = ceremony?.attributes?.cemetery?.data
-          ? getCemeteryInfoInCeremoniesDebtors(ceremony.attributes.cemetery.data, i18n.language)
-          : null
+        const cemeteryInfo = getCemeteryInfoFromCeremony(ceremony, i18n.language)
 
         const cemetery = cemeteryInfo?.slug ? (
-          <CemeteryLink slug={cemeteryInfo?.slug} title={cemeteryInfo?.title ?? ''} />
+          <CemeteryLink slug={cemeteryInfo.slug} title={cemeteryInfo.title ?? ''} />
         ) : (
           cemeteryInfo?.title
         )

--- a/next/graphql/index.ts
+++ b/next/graphql/index.ts
@@ -648,6 +648,7 @@ export type Ceremony = {
   __typename?: 'Ceremony';
   birthYear?: Maybe<Scalars['String']['output']>;
   cemetery?: Maybe<CemeteryEntityResponse>;
+  cemeteryOutsideMarianum?: Maybe<Scalars['String']['output']>;
   company?: Maybe<Scalars['String']['output']>;
   consentForPrivateFields?: Maybe<Scalars['Boolean']['output']>;
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -679,6 +680,7 @@ export type CeremonyFiltersInput = {
   and?: InputMaybe<Array<InputMaybe<CeremonyFiltersInput>>>;
   birthYear?: InputMaybe<StringFilterInput>;
   cemetery?: InputMaybe<CemeteryFiltersInput>;
+  cemeteryOutsideMarianum?: InputMaybe<StringFilterInput>;
   company?: InputMaybe<StringFilterInput>;
   consentForPrivateFields?: InputMaybe<BooleanFilterInput>;
   createdAt?: InputMaybe<DateTimeFilterInput>;
@@ -696,6 +698,7 @@ export type CeremonyFiltersInput = {
 export type CeremonyInput = {
   birthYear?: InputMaybe<Scalars['String']['input']>;
   cemetery?: InputMaybe<Scalars['ID']['input']>;
+  cemeteryOutsideMarianum?: InputMaybe<Scalars['String']['input']>;
   company?: InputMaybe<Scalars['String']['input']>;
   consentForPrivateFields?: InputMaybe<Scalars['Boolean']['input']>;
   dateTime?: InputMaybe<Scalars['DateTime']['input']>;
@@ -5096,9 +5099,9 @@ export type ProceduresEntityFragment = { __typename?: 'ProcedureEntity', attribu
 
 export type ReviewEntityFragment = { __typename?: 'ReviewEntity', id?: string | null, attributes?: { __typename?: 'Review', author: string, date: any, rating: number, description: string } | null };
 
-export type CeremonyEntityFragment = { __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, birthYear?: string | null, type?: string | null, company?: string | null, officiantProvidedBy?: string | null, consentForPrivateFields?: boolean | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, locale?: string | null } | null }> } | null } | null } | null } | null } | null };
+export type CeremonyEntityFragment = { __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, birthYear?: string | null, type?: string | null, company?: string | null, officiantProvidedBy?: string | null, consentForPrivateFields?: boolean | null, cemeteryOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, locale?: string | null } | null }> } | null } | null } | null } | null } | null };
 
-export type HomepageCeremonyEntityFragment = { __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, consentForPrivateFields?: boolean | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string } | null }> } | null } | null } | null } | null } | null };
+export type HomepageCeremonyEntityFragment = { __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, consentForPrivateFields?: boolean | null, cemeteryOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string } | null }> } | null } | null } | null } | null } | null };
 
 export type ManagedObjectSlugEntityFragment = { __typename: 'ManagedObjectEntity', id?: string | null, attributes?: { __typename?: 'ManagedObject', slug: string, title: string, type?: Enum_Managedobject_Type | null, locale?: string | null } | null };
 
@@ -5272,7 +5275,7 @@ export type HomepageCeremoniesQueryVariables = Exact<{
 }>;
 
 
-export type HomepageCeremoniesQuery = { __typename?: 'Query', ceremonies?: { __typename?: 'CeremonyEntityResponseCollection', data: Array<{ __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, consentForPrivateFields?: boolean | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string } | null }> } | null } | null } | null } | null } | null }> } | null };
+export type HomepageCeremoniesQuery = { __typename?: 'Query', ceremonies?: { __typename?: 'CeremonyEntityResponseCollection', data: Array<{ __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, consentForPrivateFields?: boolean | null, cemeteryOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string } | null }> } | null } | null } | null } | null } | null }> } | null };
 
 export type CeremoniesQueryVariables = Exact<{
   dateTime: Scalars['DateTime']['input'];
@@ -5280,7 +5283,7 @@ export type CeremoniesQueryVariables = Exact<{
 }>;
 
 
-export type CeremoniesQuery = { __typename?: 'Query', ceremonies?: { __typename?: 'CeremonyEntityResponseCollection', data: Array<{ __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, birthYear?: string | null, type?: string | null, company?: string | null, officiantProvidedBy?: string | null, consentForPrivateFields?: boolean | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, locale?: string | null } | null }> } | null } | null } | null } | null } | null }> } | null };
+export type CeremoniesQuery = { __typename?: 'Query', ceremonies?: { __typename?: 'CeremonyEntityResponseCollection', data: Array<{ __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, birthYear?: string | null, type?: string | null, company?: string | null, officiantProvidedBy?: string | null, consentForPrivateFields?: boolean | null, cemeteryOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, locale?: string | null } | null }> } | null } | null } | null } | null } | null }> } | null };
 
 export type CemeteriesInCeremoniesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -6498,6 +6501,7 @@ export const CeremonyEntityFragmentDoc = gql`
         }
       }
     }
+    cemeteryOutsideMarianum
   }
 }
     `;
@@ -6524,6 +6528,7 @@ export const HomepageCeremonyEntityFragmentDoc = gql`
         }
       }
     }
+    cemeteryOutsideMarianum
   }
 }
     `;

--- a/next/graphql/index.ts
+++ b/next/graphql/index.ts
@@ -648,7 +648,7 @@ export type Ceremony = {
   __typename?: 'Ceremony';
   birthYear?: Maybe<Scalars['String']['output']>;
   cemetery?: Maybe<CemeteryEntityResponse>;
-  cemeteryOutsideMarianum?: Maybe<Scalars['String']['output']>;
+  cemeteryNameIfOutsideMarianum?: Maybe<Scalars['String']['output']>;
   company?: Maybe<Scalars['String']['output']>;
   consentForPrivateFields?: Maybe<Scalars['Boolean']['output']>;
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -680,7 +680,7 @@ export type CeremonyFiltersInput = {
   and?: InputMaybe<Array<InputMaybe<CeremonyFiltersInput>>>;
   birthYear?: InputMaybe<StringFilterInput>;
   cemetery?: InputMaybe<CemeteryFiltersInput>;
-  cemeteryOutsideMarianum?: InputMaybe<StringFilterInput>;
+  cemeteryNameIfOutsideMarianum?: InputMaybe<StringFilterInput>;
   company?: InputMaybe<StringFilterInput>;
   consentForPrivateFields?: InputMaybe<BooleanFilterInput>;
   createdAt?: InputMaybe<DateTimeFilterInput>;
@@ -698,7 +698,7 @@ export type CeremonyFiltersInput = {
 export type CeremonyInput = {
   birthYear?: InputMaybe<Scalars['String']['input']>;
   cemetery?: InputMaybe<Scalars['ID']['input']>;
-  cemeteryOutsideMarianum?: InputMaybe<Scalars['String']['input']>;
+  cemeteryNameIfOutsideMarianum?: InputMaybe<Scalars['String']['input']>;
   company?: InputMaybe<Scalars['String']['input']>;
   consentForPrivateFields?: InputMaybe<Scalars['Boolean']['input']>;
   dateTime?: InputMaybe<Scalars['DateTime']['input']>;
@@ -5099,9 +5099,9 @@ export type ProceduresEntityFragment = { __typename?: 'ProcedureEntity', attribu
 
 export type ReviewEntityFragment = { __typename?: 'ReviewEntity', id?: string | null, attributes?: { __typename?: 'Review', author: string, date: any, rating: number, description: string } | null };
 
-export type CeremonyEntityFragment = { __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, birthYear?: string | null, type?: string | null, company?: string | null, officiantProvidedBy?: string | null, consentForPrivateFields?: boolean | null, cemeteryOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, locale?: string | null } | null }> } | null } | null } | null } | null } | null };
+export type CeremonyEntityFragment = { __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, birthYear?: string | null, type?: string | null, company?: string | null, officiantProvidedBy?: string | null, consentForPrivateFields?: boolean | null, cemeteryNameIfOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, locale?: string | null } | null }> } | null } | null } | null } | null } | null };
 
-export type HomepageCeremonyEntityFragment = { __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, consentForPrivateFields?: boolean | null, cemeteryOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string } | null }> } | null } | null } | null } | null } | null };
+export type HomepageCeremonyEntityFragment = { __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, consentForPrivateFields?: boolean | null, cemeteryNameIfOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string } | null }> } | null } | null } | null } | null } | null };
 
 export type ManagedObjectSlugEntityFragment = { __typename: 'ManagedObjectEntity', id?: string | null, attributes?: { __typename?: 'ManagedObject', slug: string, title: string, type?: Enum_Managedobject_Type | null, locale?: string | null } | null };
 
@@ -5275,7 +5275,7 @@ export type HomepageCeremoniesQueryVariables = Exact<{
 }>;
 
 
-export type HomepageCeremoniesQuery = { __typename?: 'Query', ceremonies?: { __typename?: 'CeremonyEntityResponseCollection', data: Array<{ __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, consentForPrivateFields?: boolean | null, cemeteryOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string } | null }> } | null } | null } | null } | null } | null }> } | null };
+export type HomepageCeremoniesQuery = { __typename?: 'Query', ceremonies?: { __typename?: 'CeremonyEntityResponseCollection', data: Array<{ __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, consentForPrivateFields?: boolean | null, cemeteryNameIfOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', slug: string, title: string } | null }> } | null } | null } | null } | null } | null }> } | null };
 
 export type CeremoniesQueryVariables = Exact<{
   dateTime: Scalars['DateTime']['input'];
@@ -5283,7 +5283,7 @@ export type CeremoniesQueryVariables = Exact<{
 }>;
 
 
-export type CeremoniesQuery = { __typename?: 'Query', ceremonies?: { __typename?: 'CeremonyEntityResponseCollection', data: Array<{ __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, birthYear?: string | null, type?: string | null, company?: string | null, officiantProvidedBy?: string | null, consentForPrivateFields?: boolean | null, cemeteryOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, locale?: string | null } | null }> } | null } | null } | null } | null } | null }> } | null };
+export type CeremoniesQuery = { __typename?: 'Query', ceremonies?: { __typename?: 'CeremonyEntityResponseCollection', data: Array<{ __typename?: 'CeremonyEntity', id?: string | null, attributes?: { __typename?: 'Ceremony', dateTime: any, name?: string | null, birthYear?: string | null, type?: string | null, company?: string | null, officiantProvidedBy?: string | null, consentForPrivateFields?: boolean | null, cemeteryNameIfOutsideMarianum?: string | null, cemetery?: { __typename?: 'CemeteryEntityResponse', data?: { __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, localizations?: { __typename?: 'CemeteryRelationResponseCollection', data: Array<{ __typename?: 'CemeteryEntity', attributes?: { __typename?: 'Cemetery', title: string, slug: string, locale?: string | null } | null }> } | null } | null } | null } | null } | null }> } | null };
 
 export type CemeteriesInCeremoniesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -6501,7 +6501,7 @@ export const CeremonyEntityFragmentDoc = gql`
         }
       }
     }
-    cemeteryOutsideMarianum
+    cemeteryNameIfOutsideMarianum
   }
 }
     `;
@@ -6528,7 +6528,7 @@ export const HomepageCeremonyEntityFragmentDoc = gql`
         }
       }
     }
-    cemeteryOutsideMarianum
+    cemeteryNameIfOutsideMarianum
   }
 }
     `;

--- a/next/graphql/queries/entities.gql
+++ b/next/graphql/queries/entities.gql
@@ -591,6 +591,7 @@ fragment CeremonyEntity on CeremonyEntity {
         }
       }
     }
+    cemeteryOutsideMarianum
   }
 }
 
@@ -616,6 +617,7 @@ fragment HomepageCeremonyEntity on CeremonyEntity {
         }
       }
     }
+    cemeteryOutsideMarianum
   }
 }
 

--- a/next/graphql/queries/entities.gql
+++ b/next/graphql/queries/entities.gql
@@ -591,7 +591,7 @@ fragment CeremonyEntity on CeremonyEntity {
         }
       }
     }
-    cemeteryOutsideMarianum
+    cemeteryNameIfOutsideMarianum
   }
 }
 
@@ -617,7 +617,7 @@ fragment HomepageCeremonyEntity on CeremonyEntity {
         }
       }
     }
-    cemeteryOutsideMarianum
+    cemeteryNameIfOutsideMarianum
   }
 }
 

--- a/next/utils/getCemeteryInfoInCeremoniesDebtors.tsx
+++ b/next/utils/getCemeteryInfoInCeremoniesDebtors.tsx
@@ -74,8 +74,8 @@ export const getCemeteryInfoInCeremoniesDebtorsMeili = (
  * These cemeteries are not kept as a relation to a Cemetery entry in strapi, only their name is set via a separate field
  */
 export const getCemeteryInfoFromCeremony = (ceremony: CeremonyEntityFragment, locale: string) => {
-  if (ceremony.attributes?.cemeteryOutsideMarianum) {
-    return { title: ceremony.attributes?.cemeteryOutsideMarianum, slug: undefined }
+  if (ceremony.attributes?.cemeteryNameIfOutsideMarianum) {
+    return { title: ceremony.attributes?.cemeteryNameIfOutsideMarianum, slug: undefined }
   }
 
   return ceremony?.attributes?.cemetery?.data
@@ -84,8 +84,8 @@ export const getCemeteryInfoFromCeremony = (ceremony: CeremonyEntityFragment, lo
 }
 
 export const getCemeteryInfoFromCeremonyMeili = (ceremony: CeremonyMeili, locale: string) => {
-  if (ceremony.cemeteryOutsideMarianum) {
-    return { title: ceremony.cemeteryOutsideMarianum, slug: undefined }
+  if (ceremony.cemeteryNameIfOutsideMarianum) {
+    return { title: ceremony.cemeteryNameIfOutsideMarianum, slug: undefined }
   }
 
   return ceremony?.cemetery

--- a/next/utils/getCemeteryInfoInCeremoniesDebtors.tsx
+++ b/next/utils/getCemeteryInfoInCeremoniesDebtors.tsx
@@ -1,5 +1,5 @@
-import { Maybe } from '@/graphql'
-import { CemeteryMeili } from '@/services/meili/meiliTypes'
+import { CeremonyEntityFragment, Maybe } from '@/graphql'
+import { CemeteryMeili, CeremonyMeili } from '@/services/meili/meiliTypes'
 
 /**
  * As the relation in ceremonies and debtors is always with the Slovak version, we always get the Slovak version as the
@@ -67,4 +67,28 @@ export const getCemeteryInfoInCeremoniesDebtorsMeili = (
     title: localeCemeteryTitle ?? skCemeteryTitle,
     slug: locale === 'sk' ? skCemeterySlug : localeCemeterySlug, // For the title we can fallback for SK version, but not for slug - the link wouldn't work.
   }
+}
+
+/**
+ * Some ceremonies that are uploaded into strapi belong to cemeteries that are not managed by Marianum
+ * These cemeteries are not kept as a relation to a Cemetery entry in strapi, only their name is set via a separate field
+ */
+export const getCemeteryInfoFromCeremony = (ceremony: CeremonyEntityFragment, locale: string) => {
+  if (ceremony.attributes?.cemeteryOutsideMarianum) {
+    return { title: ceremony.attributes?.cemeteryOutsideMarianum, slug: undefined }
+  }
+
+  return ceremony?.attributes?.cemetery?.data
+    ? getCemeteryInfoInCeremoniesDebtors(ceremony.attributes.cemetery.data, locale)
+    : null
+}
+
+export const getCemeteryInfoFromCeremonyMeili = (ceremony: CeremonyMeili, locale: string) => {
+  if (ceremony.cemeteryOutsideMarianum) {
+    return { title: ceremony.cemeteryOutsideMarianum, slug: undefined }
+  }
+
+  return ceremony?.cemetery
+    ? getCemeteryInfoInCeremoniesDebtorsMeili(ceremony.cemetery, locale)
+    : null
 }

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -478,6 +478,7 @@ type CemeteryRelationResponseCollection {
 type Ceremony {
   birthYear: String
   cemetery: CemeteryEntityResponse
+  cemeteryOutsideMarianum: String
   company: String
   consentForPrivateFields: Boolean
   createdAt: DateTime
@@ -506,6 +507,7 @@ input CeremonyFiltersInput {
   and: [CeremonyFiltersInput]
   birthYear: StringFilterInput
   cemetery: CemeteryFiltersInput
+  cemeteryOutsideMarianum: StringFilterInput
   company: StringFilterInput
   consentForPrivateFields: BooleanFilterInput
   createdAt: DateTimeFilterInput
@@ -523,6 +525,7 @@ input CeremonyFiltersInput {
 input CeremonyInput {
   birthYear: String
   cemetery: ID
+  cemeteryOutsideMarianum: String
   company: String
   consentForPrivateFields: Boolean
   dateTime: DateTime

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -478,7 +478,7 @@ type CemeteryRelationResponseCollection {
 type Ceremony {
   birthYear: String
   cemetery: CemeteryEntityResponse
-  cemeteryOutsideMarianum: String
+  cemeteryNameIfOutsideMarianum: String
   company: String
   consentForPrivateFields: Boolean
   createdAt: DateTime
@@ -507,7 +507,7 @@ input CeremonyFiltersInput {
   and: [CeremonyFiltersInput]
   birthYear: StringFilterInput
   cemetery: CemeteryFiltersInput
-  cemeteryOutsideMarianum: StringFilterInput
+  cemeteryNameIfOutsideMarianum: StringFilterInput
   company: StringFilterInput
   consentForPrivateFields: BooleanFilterInput
   createdAt: DateTimeFilterInput
@@ -525,7 +525,7 @@ input CeremonyFiltersInput {
 input CeremonyInput {
   birthYear: String
   cemetery: ID
-  cemeteryOutsideMarianum: String
+  cemeteryNameIfOutsideMarianum: String
   company: String
   consentForPrivateFields: Boolean
   dateTime: DateTime

--- a/strapi/src/api/ceremony/content-types/ceremony/schema.json
+++ b/strapi/src/api/ceremony/content-types/ceremony/schema.json
@@ -43,6 +43,9 @@
       "relation": "oneToOne",
       "target": "api::cemetery.cemetery"
     },
+    "cemeteryOutsideMarianum": {
+      "type": "string"
+    },
     "consentForPrivateFields": {
       "type": "boolean"
     },

--- a/strapi/src/api/ceremony/content-types/ceremony/schema.json
+++ b/strapi/src/api/ceremony/content-types/ceremony/schema.json
@@ -43,7 +43,7 @@
       "relation": "oneToOne",
       "target": "api::cemetery.cemetery"
     },
-    "cemeteryOutsideMarianum": {
+    "cemeteryNameIfOutsideMarianum": {
       "type": "string"
     },
     "consentForPrivateFields": {

--- a/strapi/src/plugins/ceremonies-debtor-list/admin/src/components/ImportSection.tsx
+++ b/strapi/src/plugins/ceremonies-debtor-list/admin/src/components/ImportSection.tsx
@@ -33,6 +33,8 @@ const ImportSection = ({ type }: ImportSectionProps) => {
   const [success, setSuccess] = useState<any>(null)
   const [error, setError] = useState<any>(null)
 
+  const [showAdditionalMessage, setShowAdditionalMessage] = useState(true)
+
   const handleSubmit = () => {
     const file = inputFileRef.current!.files![0] // TODO fix !
 
@@ -76,18 +78,31 @@ const ImportSection = ({ type }: ImportSectionProps) => {
         </Typography>
         {loading && <Loader />}
         {success && (
-          <Alert
-            title="Nahrávanie úspešné"
-            action={
-              success.data?.importId && (
-                <Link to={importLinks[type](success.data.importId)}>Zobraziť nahrané dáta</Link>
-              )
-            }
-            variant="success"
-            onClose={() => setSuccess(null)}
-          >
-            {success.data.message} ({success.data.executionTime}ms)
-          </Alert>
+          <Stack spacing={2}>
+            <Alert
+              title="Nahrávanie úspešné"
+              action={
+                success.data?.importId && (
+                  <Link to={importLinks[type](success.data.importId)}>
+                    Zobraziť nahrané dáta
+                  </Link>
+                )
+              }
+              variant="success"
+              onClose={() => setSuccess(null)}
+            >
+              {success.data.message} ({success.data.executionTime}ms)
+            </Alert>
+            {showAdditionalMessage && success.data.additionalMessage ? (
+              <Alert
+                title="V dátach sa nachádzajú cintoríny bez záznamu v Strapi: "
+                variant="default"
+                onClose={() => setShowAdditionalMessage(false)}
+              >
+                {success.data.additionalMessage}
+              </Alert>
+            ) : null}
+          </Stack>
         )}
         {error && (
           <Alert title="Nahrávanie neúspešné" variant="danger" onClose={() => setError(null)}>

--- a/strapi/src/plugins/ceremonies-debtor-list/server/controllers/index.ts
+++ b/strapi/src/plugins/ceremonies-debtor-list/server/controllers/index.ts
@@ -82,6 +82,8 @@ export default {
       }
     },
     async updateCeremonies(ctx) {
+      const startTime = Date.now()
+
       ctx.request.socket.setTimeout(120000)
 
       const file = ctx.request.files?.file
@@ -175,9 +177,27 @@ export default {
         const successMessage = parsedCeremonies
           .map(({ day, data }) => `${day} (${data.length})`)
           .join(", ")
+
+        const isAnyCemeteryOutsideMarianum = parsedCeremonies.some(
+          (ceremonies) => ceremonies.cemeteriesOutsideMarianum.length > 0
+        )
+
+        const cemeteriesOutsideMarianumMessage = isAnyCemeteryOutsideMarianum
+          ? parsedCeremonies
+              .filter((ceremonies) => {
+                return ceremonies.cemeteriesOutsideMarianum.length > 0;
+              })
+              .map(({ day, cemeteriesOutsideMarianum }) => {
+                return `${cemeteriesOutsideMarianum.join(", ")} (hárok ${day})`;
+              })
+              .join(", ") + "."
+          : undefined
+
         ctx.body = {
           message: `Nahraných ${successMessage} obradov.`,
+          additionalMessage: cemeteriesOutsideMarianumMessage,
           importId,
+          executionTime: Date.now() - startTime,
         }
       } catch (e) {
         ctx.status = 400

--- a/strapi/src/plugins/ceremonies-debtor-list/server/helpers/parse-ceremonies-xlsx.ts
+++ b/strapi/src/plugins/ceremonies-debtor-list/server/helpers/parse-ceremonies-xlsx.ts
@@ -95,13 +95,14 @@ export const parseCeremoniesXlsx = (
         }
 
         const dateTime = parsedDateTime.toISOString();
-        const cemeteryId = getCemeteryIdBySlug(
-          cemeterySlug,
-          cemeteriesSlugIdMap,
-          `Cintorín na riadku ${
-            index + 3
-          } v zošite "${sheetName}" s "slug" "${cemeterySlug}" neexistuje alebo jeho hodnota "allowInCeremonies" nie je nastavená na "true".`
-        );
+
+        const cemeteryId =
+          cemeterySlug && cemeterySlug in cemeteriesSlugIdMap
+            ? cemeteriesSlugIdMap[cemeterySlug]
+            : undefined;
+
+        const isCemeteryOutsideMarianum = !cemeteryId;
+
         const consentForPrivateFields = consentForPrivateFieldsRaw === "A";
 
         return {
@@ -112,6 +113,9 @@ export const parseCeremoniesXlsx = (
           company,
           officiantProvidedBy,
           cemetery: cemeteryId,
+          cemeteryNameIfOutsideMarianum: isCemeteryOutsideMarianum
+            ? cemeterySlug
+            : undefined,
           consentForPrivateFields,
           importId,
         };

--- a/strapi/src/plugins/ceremonies-debtor-list/server/helpers/parse-ceremonies-xlsx.ts
+++ b/strapi/src/plugins/ceremonies-debtor-list/server/helpers/parse-ceremonies-xlsx.ts
@@ -61,6 +61,13 @@ export const parseCeremoniesXlsx = (
       )}\nPrijatá hlavička: ${JSON.stringify(header)}`
     );
 
+    /**
+     * Some imported ceremonies may be related to cemeteries that are not managed by Marianum.
+     * These cemeteries have no Cemetery entries in Strapi, but we allow importing them.
+     * After successful import, we display a message with names of these 'outside Marianum' cemeteries.
+     */
+    const cemeteriesOutsideMarianum = new Set<string>();
+
     const parsedData = data
       .splice(1)
       .filter((row) => row.length !== 0 /* Filter empty rows */)
@@ -102,6 +109,8 @@ export const parseCeremoniesXlsx = (
             : undefined;
 
         const isCemeteryOutsideMarianum = !cemeteryId;
+        if (isCemeteryOutsideMarianum)
+          cemeteriesOutsideMarianum.add(cemeterySlug);
 
         const consentForPrivateFields = consentForPrivateFieldsRaw === "A";
 
@@ -121,6 +130,6 @@ export const parseCeremoniesXlsx = (
         };
       });
 
-    return { day: sheetName, data: parsedData };
+    return { day: sheetName, data: parsedData, cemeteriesOutsideMarianum: [...cemeteriesOutsideMarianum] };
   });
 };

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1003,6 +1003,7 @@ export interface ApiCeremonyCeremony extends Schema.CollectionType {
       'oneToOne',
       'api::cemetery.cemetery'
     >;
+    cemeteryOutsideMarianum: Attribute.String;
     company: Attribute.String;
     consentForPrivateFields: Attribute.Boolean;
     createdAt: Attribute.DateTime;

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1003,7 +1003,7 @@ export interface ApiCeremonyCeremony extends Schema.CollectionType {
       'oneToOne',
       'api::cemetery.cemetery'
     >;
-    cemeteryOutsideMarianum: Attribute.String;
+    cemeteryNameIfOutsideMarianum: Attribute.String;
     company: Attribute.String;
     consentForPrivateFields: Attribute.Boolean;
     createdAt: Attribute.DateTime;


### PR DESCRIPTION
### Description
- ceremonies import plugin was adjusted to allow custom cemetery names
- best reviewed commit by commit

### Testing
- try importing a file that has some ceremonies with custom cemetery names, for example [Zoznam obradov 4.xlsx](https://github.com/user-attachments/files/20712574/Zoznam.obradov.4.xlsx)
- check that
  - ceremonies with cemeteries already in strapi should be imported as before
  - ceremonies with "external" cemeteries should also be imported with no error, but instead of recieving a relation to a cemetery entity, they should recieve the cemetery name in field `cemeteryNameIfOutsideMarianum`
  - after successful import, a new message banner should be displayed, with (see screenshot below) - it lists all cemetery names, that were not in strapi when importing
  - all ceremonies with external cemeteries should be displayed correctly in corresponding sections (cemetery names should be displayed, but just as plain text instead of link to detail page)

### Screenshots
![image](https://github.com/user-attachments/assets/d2a24b60-5f49-496a-9a55-7549251bd9b4)

### Additional notes

- Cemetery filters weren't changed, so external cemeteries will not be displayed in filter options
![image](https://github.com/user-attachments/assets/b277aaf8-201f-401e-8a8f-1bf1c55672a4)