### PR TITLE
#651 WIP Managed objects meilisearch

### DIFF
--- a/next/components/molecules/MapObjectsCategoryTags.tsx
+++ b/next/components/molecules/MapObjectsCategoryTags.tsx
@@ -1,0 +1,57 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'next-i18next'
+
+import TagToggle from '@/components/atoms/TagToggle'
+
+export type TagProps = {
+  title: string
+  slug: string
+  key: string
+}
+type MapObjectsCategoryTagsProps = {
+  queryKey: string[]
+  fetcher: () => Promise<TagProps[]>
+  toggleSelectedCategory: (category: string) => void
+  selectedCategories: Record<string, boolean>
+}
+
+const MapObjectsCategoryTags = ({
+  queryKey,
+  fetcher,
+  toggleSelectedCategory,
+  selectedCategories,
+}: MapObjectsCategoryTagsProps) => {
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: [queryKey],
+    queryFn: fetcher,
+    placeholderData: keepPreviousData,
+  })
+
+  const { t } = useTranslation()
+
+  // TODO replace by proper error
+  if (isError) {
+    return <div className="whitespace-pre">Error: {JSON.stringify(error, null, 2)}</div>
+  }
+
+  const options = isPending ? [] : [...data]
+
+  return (
+    <ul aria-label={t('MapSection.filtering')} className="flex flex-wrap gap-2">
+      {options.map((option) => {
+        return (
+          <li key={option.key}>
+            <TagToggle
+              isSelected={selectedCategories[option.slug]}
+              onChange={() => toggleSelectedCategory(option.slug)}
+            >
+              {option.title}
+            </TagToggle>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export default MapObjectsCategoryTags

--- a/next/components/molecules/MapObjectsCategoryTags.tsx
+++ b/next/components/molecules/MapObjectsCategoryTags.tsx
@@ -2,6 +2,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'next-i18next'
 
 import TagToggle from '@/components/atoms/TagToggle'
+import { ManagedObjectCategoryEntityFragment } from '@/graphql'
 
 export type TagProps = {
   title: string
@@ -13,6 +14,7 @@ type MapObjectsCategoryTagsProps = {
   fetcher: () => Promise<TagProps[]>
   toggleSelectedCategory: (category: string) => void
   selectedCategories: Record<string, boolean>
+  defaultCategories: ManagedObjectCategoryEntityFragment[] | undefined
 }
 
 const MapObjectsCategoryTags = ({
@@ -20,6 +22,7 @@ const MapObjectsCategoryTags = ({
   fetcher,
   toggleSelectedCategory,
   selectedCategories,
+  defaultCategories,
 }: MapObjectsCategoryTagsProps) => {
   const { data, isPending, isError, error } = useQuery({
     queryKey: [queryKey],
@@ -34,7 +37,15 @@ const MapObjectsCategoryTags = ({
     return <div className="whitespace-pre">Error: {JSON.stringify(error, null, 2)}</div>
   }
 
-  const options = isPending ? [] : [...data]
+  const options = isPending
+    ? []
+    : data.filter((fetchedData: TagProps) => {
+        if (!defaultCategories) return true
+
+        return defaultCategories.find(
+          (defaultCategory) => defaultCategory.attributes?.slug === fetchedData.slug,
+        )
+      })
 
   return (
     <ul aria-label={t('MapSection.filtering')} className="flex flex-wrap gap-2">

--- a/next/components/sections/MapOfManagedObjectsSection.tsx
+++ b/next/components/sections/MapOfManagedObjectsSection.tsx
@@ -148,6 +148,7 @@ const MapOfManagedObjectsSection = ({ section }: MapOfManagedObjectsSectionProps
               selectedCategories={selectedCategories}
               queryKey={['ManagedObjectCategories']}
               fetcher={mappedFetcher}
+              defaultCategories={section.categories?.data}
             />
             <ul aria-label={t('MapSection.filtering')} className="flex flex-wrap gap-2">
               {Object.entries(selectedTypes).map(([type]) => {

--- a/next/graphql/index.ts
+++ b/next/graphql/index.ts
@@ -5394,9 +5394,7 @@ export type CemeteriesQueryVariables = Exact<{
 
 export type CemeteriesQuery = { __typename?: 'Query', cemeteries?: { __typename?: 'CemeteryEntityResponseCollection', data: Array<{ __typename: 'CemeteryEntity', id?: string | null, attributes?: { __typename?: 'Cemetery', type?: Enum_Cemetery_Type | null, description?: string | null, navigateToLink?: string | null, latitude?: number | null, longitude?: number | null, address?: string | null, title: string, slug: string, locale?: string | null, contact?: { __typename?: 'ContactEntityResponse', data?: { __typename?: 'ContactEntity', id?: string | null, attributes?: { __typename?: 'Contact', title: string, position?: string | null, email?: string | null, phone1?: string | null, phone2?: string | null } | null } | null } | null, medias?: { __typename?: 'UploadFileRelationResponseCollection', data: Array<{ __typename?: 'UploadFileEntity', id?: string | null, attributes?: { __typename?: 'UploadFile', url: string, name: string, alternativeText?: string | null, caption?: string | null, size: number, width?: number | null, height?: number | null } | null }> } | null, seo?: { __typename?: 'ComponentGeneralSeo', metaTitle?: string | null, metaDescription?: string | null, keywords?: string | null } | null, documents?: { __typename?: 'ComponentSectionsDocumentGroup', id: string, title?: string | null, documents?: Array<{ __typename?: 'ComponentBlocksDocumentItem', document?: { __typename?: 'DocumentEntityResponse', data?: { __typename: 'DocumentEntity', id?: string | null, attributes?: { __typename?: 'Document', publishedAt?: any | null, title: string, slug: string, file: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', id?: string | null, attributes?: { __typename?: 'UploadFile', url: string, name: string, size: number, ext?: string | null } | null } | null }, documentCategory?: { __typename?: 'DocumentCategoryEntityResponse', data?: { __typename?: 'DocumentCategoryEntity', id?: string | null, attributes?: { __typename?: 'DocumentCategory', title: string, slug: string } | null } | null } | null } | null } | null } | null } | null> | null } | null, gallery?: { __typename?: 'ComponentSectionsGallery', id: string, title?: string | null, medias?: { __typename?: 'UploadFileRelationResponseCollection', data: Array<{ __typename?: 'UploadFileEntity', id?: string | null, attributes?: { __typename?: 'UploadFile', url: string, name: string, alternativeText?: string | null, caption?: string | null, size: number, width?: number | null, height?: number | null } | null }> } | null } | null, video?: { __typename?: 'ComponentSectionsIframeSection', id: string, title?: string | null, iframeTitle: string, body?: string | null, url: string } | null, cemeteryCategory?: { __typename?: 'CemeteryCategoryEntityResponse', data?: { __typename?: 'CemeteryCategoryEntity', id?: string | null, attributes?: { __typename?: 'CemeteryCategory', title: string, slug: string } | null } | null } | null, overrideOpeningHours?: { __typename?: 'ComponentBlocksOpeningHoursUniversal', days?: Array<{ __typename?: 'ComponentBlocksOpeningHoursItem', label?: string | null, time?: string | null } | null> | null } | null } | null }> } | null };
 
-export type CemeteryCategoriesQueryVariables = Exact<{
-  locale: Scalars['I18NLocaleCode']['input'];
-}>;
+export type CemeteryCategoriesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type CemeteryCategoriesQuery = { __typename?: 'Query', cemeteryCategories?: { __typename?: 'CemeteryCategoryEntityResponseCollection', data: Array<{ __typename?: 'CemeteryCategoryEntity', id?: string | null, attributes?: { __typename?: 'CemeteryCategory', title: string, slug: string } | null }> } | null };
@@ -5416,9 +5414,7 @@ export type ManagedObjectsQueryVariables = Exact<{
 
 export type ManagedObjectsQuery = { __typename?: 'Query', managedObjects?: { __typename?: 'ManagedObjectEntityResponseCollection', data: Array<{ __typename: 'ManagedObjectEntity', id?: string | null, attributes?: { __typename?: 'ManagedObject', description?: string | null, address?: string | null, navigateToLink?: string | null, latitude?: number | null, longitude?: number | null, slug: string, title: string, type?: Enum_Managedobject_Type | null, locale?: string | null, medias?: { __typename?: 'UploadFileRelationResponseCollection', data: Array<{ __typename?: 'UploadFileEntity', id?: string | null, attributes?: { __typename?: 'UploadFile', url: string, name: string, alternativeText?: string | null, caption?: string | null, size: number, width?: number | null, height?: number | null } | null }> } | null, contact?: { __typename?: 'ContactEntityResponse', data?: { __typename?: 'ContactEntity', id?: string | null, attributes?: { __typename?: 'Contact', title: string, position?: string | null, email?: string | null, phone1?: string | null, phone2?: string | null } | null } | null } | null, seo?: { __typename?: 'ComponentGeneralSeo', metaTitle?: string | null, metaDescription?: string | null, keywords?: string | null } | null, managedObjectCategory?: { __typename?: 'ManagedObjectCategoryEntityResponse', data?: { __typename?: 'ManagedObjectCategoryEntity', id?: string | null, attributes?: { __typename?: 'ManagedObjectCategory', title: string, slug: string } | null } | null } | null } | null }> } | null };
 
-export type ManagedObjectCategoriesQueryVariables = Exact<{
-  locale: Scalars['I18NLocaleCode']['input'];
-}>;
+export type ManagedObjectCategoriesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type ManagedObjectCategoriesQuery = { __typename?: 'Query', managedObjectCategories?: { __typename?: 'ManagedObjectCategoryEntityResponseCollection', data: Array<{ __typename?: 'ManagedObjectCategoryEntity', id?: string | null, attributes?: { __typename?: 'ManagedObjectCategory', title: string, slug: string } | null }> } | null };
@@ -6930,7 +6926,7 @@ export const CemeteriesDocument = gql`
 }
     ${CemeteryEntityFragmentDoc}`;
 export const CemeteryCategoriesDocument = gql`
-    query CemeteryCategories($locale: I18NLocaleCode!) {
+    query CemeteryCategories {
   cemeteryCategories(pagination: {limit: -1}) {
     data {
       ...CemeteryCategoryEntity
@@ -6957,7 +6953,7 @@ export const ManagedObjectsDocument = gql`
 }
     ${ManagedObjectEntityFragmentDoc}`;
 export const ManagedObjectCategoriesDocument = gql`
-    query ManagedObjectCategories($locale: I18NLocaleCode!) {
+    query ManagedObjectCategories {
   managedObjectCategories(pagination: {limit: -1}) {
     data {
       ...ManagedObjectCategoryEntity
@@ -7232,7 +7228,7 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     Cemeteries(variables: CemeteriesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CemeteriesQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<CemeteriesQuery>(CemeteriesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'Cemeteries', 'query', variables);
     },
-    CemeteryCategories(variables: CemeteryCategoriesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CemeteryCategoriesQuery> {
+    CemeteryCategories(variables?: CemeteryCategoriesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CemeteryCategoriesQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<CemeteryCategoriesQuery>(CemeteryCategoriesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'CemeteryCategories', 'query', variables);
     },
     ManagedObjectBySlug(variables: ManagedObjectBySlugQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ManagedObjectBySlugQuery> {
@@ -7241,7 +7237,7 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     ManagedObjects(variables: ManagedObjectsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ManagedObjectsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<ManagedObjectsQuery>(ManagedObjectsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'ManagedObjects', 'query', variables);
     },
-    ManagedObjectCategories(variables: ManagedObjectCategoriesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ManagedObjectCategoriesQuery> {
+    ManagedObjectCategories(variables?: ManagedObjectCategoriesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ManagedObjectCategoriesQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<ManagedObjectCategoriesQuery>(ManagedObjectCategoriesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'ManagedObjectCategories', 'query', variables);
     },
     BundleBySlug(variables: BundleBySlugQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<BundleBySlugQuery> {

--- a/next/graphql/queries/queries.gql
+++ b/next/graphql/queries/queries.gql
@@ -94,7 +94,7 @@ query Cemeteries($locale: I18NLocaleCode!) {
   }
 }
 
-query CemeteryCategories($locale: I18NLocaleCode!) {
+query CemeteryCategories {
   cemeteryCategories(pagination: { limit: -1 }) {
     data {
       ...CemeteryCategoryEntity
@@ -118,7 +118,7 @@ query ManagedObjects($locale: I18NLocaleCode!) {
   }
 }
 
-query ManagedObjectCategories($locale: I18NLocaleCode!) {
+query ManagedObjectCategories {
   managedObjectCategories(pagination: { limit: -1 }) {
     data {
       ...ManagedObjectCategoryEntity

--- a/next/services/fetchers/cemeteries/cemeteriesFetcher.ts
+++ b/next/services/fetchers/cemeteries/cemeteriesFetcher.ts
@@ -1,4 +1,10 @@
+import { Sort } from '@/components/molecules/SortSelect'
 import { client } from '@/services/graphql/gqlClient'
+import { meiliClient } from '@/services/meili/meiliClient'
+import { CemeteryMeili } from '@/services/meili/meiliTypes'
+import { SearchIndexWrapped, unwrapFromSearchIndex } from '@/services/meili/searchIndexWrapped'
+import { getMeilisearchPageOptions } from '@/utils/getMeilisearchPageOptions'
+import { isDefined } from '@/utils/isDefined'
 
 export const getGraphqlCemeteriesQueryKey = (locale: string) => ['Cemeteries', locale]
 
@@ -8,5 +14,48 @@ export const getGraphqlCemeteriesQuery = (locale: string) => {
   return {
     queryKey: getGraphqlCemeteriesQueryKey(locale),
     queryFn: () => graphqlCemeteriesFetcher(locale),
+  } as const
+}
+
+export type CemeteriesFilters = {
+  pageSize: number
+  search: string
+  categoryId: string | null
+  page: number
+  sort: Sort
+  filetype: string | null
+}
+
+export const cemeteriesDefaultFilters: CemeteriesFilters = {
+  pageSize: 24,
+  search: '',
+  page: 1,
+  categoryId: null,
+  sort: 'newest',
+  filetype: null,
+}
+
+export const getMeiliCemeteriesQueryKey = (filters: CemeteriesFilters) => ['Cemeteries', filters]
+
+export const meiliCemeteriesFetcher = (filters: CemeteriesFilters) => {
+  return meiliClient
+    .index('search_index')
+    .search<SearchIndexWrapped<'cemetery', CemeteryMeili>>(filters.search, {
+      ...getMeilisearchPageOptions({ page: filters.page, pageSize: filters.pageSize }),
+      filter: [
+        'type = "cemetery"',
+        isDefined(filters.categoryId)
+          ? `cemetery.cemeteryCategory.id = ${filters.categoryId}`
+          : null,
+      ].filter(Boolean) as string[],
+      sort: ['cemetery.title:asc'],
+    })
+    .then(unwrapFromSearchIndex('cemetery'))
+}
+
+export const getMeiliCemeteriesQuery = (filters: CemeteriesFilters = cemeteriesDefaultFilters) => {
+  return {
+    queryKey: getMeiliCemeteriesQueryKey(filters),
+    queryFn: () => meiliCemeteriesFetcher(filters),
   } as const
 }

--- a/next/services/fetchers/managedObjectsFetcher.ts
+++ b/next/services/fetchers/managedObjectsFetcher.ts
@@ -1,4 +1,10 @@
+import { Sort } from '@/components/molecules/SortSelect'
 import { client } from '@/services/graphql/gqlClient'
+import { meiliClient } from '@/services/meili/meiliClient'
+import { ManagedObjectMeili } from '@/services/meili/meiliTypes'
+import { SearchIndexWrapped, unwrapFromSearchIndex } from '@/services/meili/searchIndexWrapped'
+import { getMeilisearchPageOptions } from '@/utils/getMeilisearchPageOptions'
+import { isDefined } from '@/utils/isDefined'
 
 export const getGraphqlManagedObjectsQueryKey = (locale: string) => ['ManagedObjects', locale]
 
@@ -8,5 +14,53 @@ export const getGraphqlManagedObjectsQuery = (locale: string) => {
   return {
     queryKey: getGraphqlManagedObjectsQueryKey(locale),
     queryFn: () => graphqlManagedObjectsFetcher(locale),
+  } as const
+}
+
+export type ManagedObjectsFilters = {
+  pageSize: number
+  search: string
+  categoryId: string | null
+  page: number
+  sort: Sort
+  filetype: string | null
+}
+
+export const managedObjectsDefaultFilters: ManagedObjectsFilters = {
+  pageSize: 24,
+  search: '',
+  page: 1,
+  categoryId: null,
+  sort: 'newest',
+  filetype: null,
+}
+
+export const getMeiliManagedObjectsQueryKey = (filters: ManagedObjectsFilters) => [
+  'ManagedObjects',
+  filters,
+]
+
+export const meiliManagedObjectsFetcher = (filters: ManagedObjectsFilters) => {
+  return meiliClient
+    .index('search_index')
+    .search<SearchIndexWrapped<'managed-object', ManagedObjectMeili>>(filters.search, {
+      ...getMeilisearchPageOptions({ page: filters.page, pageSize: filters.pageSize }),
+      filter: [
+        'type = "managed-object"',
+        isDefined(filters.categoryId)
+          ? `managed-object.managedObjectCategory.id = ${filters.categoryId}`
+          : null,
+      ].filter(Boolean) as string[],
+      sort: ['managed-object.title:asc'],
+    })
+    .then(unwrapFromSearchIndex('managed-object'))
+}
+
+export const getMeiliManagedObjectsQuery = (
+  filters: ManagedObjectsFilters = managedObjectsDefaultFilters,
+) => {
+  return {
+    queryKey: getMeiliManagedObjectsQueryKey(filters),
+    queryFn: () => meiliManagedObjectsFetcher(filters),
   } as const
 }

--- a/next/services/meili/meiliTypes.ts
+++ b/next/services/meili/meiliTypes.ts
@@ -9,6 +9,7 @@ import {
   Disclosure,
   Document,
   DocumentCategory,
+  ManagedObject,
   UploadFile,
 } from '@/graphql'
 
@@ -47,6 +48,11 @@ export type DocumentMeili = Omit<Document, '__typename' | 'documentCategory' | '
   id: string
   documentCategory: Omit<DocumentCategory, '__typename' | 'documents'>
   file: Omit<UploadFile, '__typename'>
+}
+
+export type ManagedObjectMeili = Omit<ManagedObject, '__typename' | 'localizations'> & {
+  id: string
+  localizations: ManagedObjectMeili[]
 }
 
 /**

--- a/strapi/config/plugins.meilisearch.config.ts
+++ b/strapi/config/plugins.meilisearch.config.ts
@@ -33,6 +33,8 @@ const searchIndexSettings = {
     "cemetery.title",
     // Document
     "document.title",
+    // ManagedObject
+    "managed-object.title",
   ],
   filterableAttributes: [
     // All
@@ -46,6 +48,10 @@ const searchIndexSettings = {
     // Document
     "document.documentCategory.id",
     "document.file.ext",
+    //Cemetery
+    "cemetery.cemeteryCategory.id",
+    //Managed Object
+    "managed-object.managedObjectCategory.id",
   ],
   sortableAttributes: [
     // Article
@@ -193,6 +199,15 @@ const config = {
           ? new Date(entry.updatedAt).getTime()
           : undefined,
       }),
+  },
+  "managed-object": {
+    indexName: "search_index",
+    entriesQuery: {
+      locale: "all",
+    },
+    settings: searchIndexSettings,
+    transformEntry: ({ entry }) =>
+      wrapSearchIndexEntry("managed-object", entry),
   },
 };
 


### PR DESCRIPTION
### Description

Unfinished work in progress
connected to this story #599 

### Prerequisities

After current strapi changes from #658 #653 #647 are released and setup 

### Changes in this PR
Map of managed objects - tags are from categories that are set in strapi
Functionality should for tags
Managed objects are get from Meilisearch

### Unfinished changes
- Meilisearch setup for cemeteries, but not used in Map of objects, whole setup should be similar to Managed Objects, or better create one component that work with the map and 2 separate documents that use this one common component
- Filtering for list of managed objects and map with managed objects based on the selected category tag is not working due to different object structure with meilisearch filters and tags filters
- While setup should by default work with categories that are set in strapi, or show all (map of managed objects should be prepared for this setup)
- getFull path is expecting different objects this needs to be fixed 
<img width="527" height="126" alt="image" src="https://github.com/user-attachments/assets/7b48b482-dd58-41d3-9ae5-7df3e1cba59e" />
- some eslint issues

